### PR TITLE
dev(hansbug): add parsable datamodel for LLM system

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,24 +122,24 @@ print(f"Loaded Model: {model}")
 pprint(model)
 
 # Initialize conversation history with a system prompt
-history = LLMHistory().set_system_prompt(
-    'tell me the appearance of this guy, use json format, like {\'description\': \'xxxxx\', \'name\': \'original name\'}.'
-).append_user(
-    'donald trump'
+history = LLMHistory().with_system_prompt(
+  'tell me the appearance of this guy, use json format, like {\'description\': \'xxxxx\', \'name\': \'original name\'}.'
+).with_user_message(
+  'donald trump'
 )
 
 # Ask the model a question and get a streaming response
 # with_reasoning=True will include any internal reasoning from the model in the stream
 f = model.ask_stream(
-    messages=history.to_json(),
-    with_reasoning=True,
+  messages=history.to_json(),
+  with_reasoning=True,
 )
 print(f"\nStreaming Response (with reasoning):\n")
 
 # Iterate through the stream and print chunks as they arrive
 for chunk in f:
-    print(chunk, end='')
-    sys.stdout.flush()
+  print(chunk, end='')
+  sys.stdout.flush()
 
 print(f"\n\nAccumulated Reasoning: {f.reasoning_content}")
 print(f"Accumulated Content: {f.content}")
@@ -181,7 +181,7 @@ model = FakeLLMModel(stream_wps=10)
 
 # 1. Always return a specific response
 model.response_always("Hello, I am a fake LLM model ready for your commands!")
-history_always = LLMHistory().append_user("Hi there!")
+history_always = LLMHistory().with_user_message("Hi there!")
 response_always = model.ask(history_always.to_json())
 print(f"Always Response: {response_always}")
 # Expected Output: Always Response: Hello, I am a fake LLM model ready for your commands!
@@ -191,12 +191,12 @@ model = FakeLLMModel(stream_wps=10)  # Re-initialize to clear previous rules
 model.response_when_keyword_in_last_message("weather", "The weather is sunny with a chance of fake clouds.")
 model.response_when_keyword_in_last_message(["time", "hour"], "It\'s always coffee o\'clock in the fake world.")
 
-history_weather = LLMHistory().append_user("What\'s the weather like?")
+history_weather = LLMHistory().with_user_message("What\'s the weather like?")
 response_weather = model.ask(history_weather.to_json())
 print(f"Weather Response: {response_weather}")
 # Expected Output: Weather Response: The weather is sunny with a chance of fake clouds.
 
-history_time = LLMHistory().append_user("What time is it?")
+history_time = LLMHistory().with_user_message("What time is it?")
 response_time = model.ask(history_time.to_json())
 print(f"Time Response: {response_time}")
 # Expected Output: Time Response: It\'s always coffee o\'clock in the fake world.
@@ -206,18 +206,18 @@ model = FakeLLMModel(stream_wps=10)  # Re-initialize to clear previous rules
 
 
 def long_conversation_check(messages, **params):
-    return len(messages) > 2
+  return len(messages) > 2
 
 
 model.response_when(long_conversation_check, "This is a long conversation, isn\'t it?")
 model.response_always("Short conversation.")  # Fallback for shorter conversations
 
-history_short = LLMHistory().append_user("Hello.")
+history_short = LLMHistory().with_user_message("Hello.")
 response_short = model.ask(history_short.to_json())
 print(f"Short Conversation: {response_short}")
 # Expected Output: Short Conversation: Short conversation.
 
-history_long = LLMHistory().append_user("Hello.").append_assistant("Hi!").append_user("How are you?")
+history_long = LLMHistory().with_user_message("Hello.").with_assistant_message("Hi!").with_user_message("How are you?")
 response_long = model.ask(history_long.to_json())
 print(f"Long Conversation: {response_long}")
 # Expected Output: Long Conversation: This is a long conversation, isn\'t it?
@@ -226,16 +226,16 @@ print(f"Long Conversation: {response_long}")
 model = FakeLLMModel(stream_wps=5)  # Slower streaming for demonstration
 model.response_always(("Thinking step by step...", "The final answer is 42."))
 
-history_stream = LLMHistory().append_user("What is the meaning of life?")
+history_stream = LLMHistory().with_user_message("What is the meaning of life?")
 stream = model.ask_stream(history_stream.to_json(), with_reasoning=True)
 
 print("\nStreaming Response (with reasoning):\n")
 for chunk in stream:
-    print(chunk, end='')
-    sys.stdout.flush()
+  print(chunk, end='')
+  sys.stdout.flush()
 
-    print(f"\n\nAccumulated Reasoning: {stream.reasoning_content}")
-    print(f"Accumulated Content: {stream.content}")
+  print(f"\n\nAccumulated Reasoning: {stream.reasoning_content}")
+  print(f"Accumulated Content: {stream.content}")
 # Expected Output (with simulated delay):
 # Streaming Response (with reasoning):
 # Thinking step by step...The final answer is 42.

--- a/docs/source/api_doc/history/history.rst
+++ b/docs/source/api_doc/history/history.rst
@@ -22,7 +22,7 @@ LLMHistory
 -----------------------------------------------------
 
 .. autoclass:: LLMHistory
-    :members: __init__,__getitem__,__len__,append,append_user,append_assistant,set_system_prompt,to_json,clone
+    :members: __init__,__getitem__,__len__,with_message,with_user_message,with_assistant_message,with_system_prompt,to_json,clone,__hash__,__eq__,dump_json,load_json,dump_yaml,load_yaml
 
 
 create\_llm\_message

--- a/docs/source/api_doc/model/base.rst
+++ b/docs/source/api_doc/model/base.rst
@@ -10,6 +10,6 @@ LLMModel
 -----------------------------------------------------
 
 .. autoclass:: LLMModel
-    :members: ask,ask_stream
+    :members: ask,ask_stream,__eq__,__hash__
 
 

--- a/docs/source/api_doc/model/fake.rst
+++ b/docs/source/api_doc/model/fake.rst
@@ -22,6 +22,6 @@ FakeLLMModel
 -----------------------------------------------------
 
 .. autoclass:: FakeLLMModel
-    :members: __init__,__setattr__,__delattr__,stream_fps,rules_count,with_stream_wps,response_always,response_when,response_when_keyword_in_last_message,clear_rules,ask,ask_stream,__repr__
+    :members: __init__,__setattr__,__delattr__,stream_wps,rules_count,with_stream_wps,response_always,response_when,response_when_keyword_in_last_message,clear_rules,ask,ask_stream,__repr__
 
 

--- a/docs/source/api_doc/model/fake.rst
+++ b/docs/source/api_doc/model/fake.rst
@@ -22,6 +22,6 @@ FakeLLMModel
 -----------------------------------------------------
 
 .. autoclass:: FakeLLMModel
-    :members: __init__,rules_count,response_always,response_when,response_when_keyword_in_last_message,ask,ask_stream,__repr__
+    :members: __init__,__setattr__,__delattr__,stream_fps,rules_count,with_stream_wps,response_always,response_when,response_when_keyword_in_last_message,clear_rules,ask,ask_stream,__repr__
 
 

--- a/docs/source/api_doc/model/fake.rst
+++ b/docs/source/api_doc/model/fake.rst
@@ -12,6 +12,13 @@ FakeResponseTyping
 .. autodata:: FakeResponseTyping
 
 
+FakeResponseSequence
+-----------------------------------------------------
+
+.. autoclass:: FakeResponseSequence
+    :members: __init__,current_index,total_responses,has_more_responses,rule_check,response,advance,reset,__eq__,__hash__,__repr__
+
+
 FakeResponseStream
 -----------------------------------------------------
 
@@ -22,6 +29,6 @@ FakeLLMModel
 -----------------------------------------------------
 
 .. autoclass:: FakeLLMModel
-    :members: __init__,__setattr__,__delattr__,stream_wps,rules_count,with_stream_wps,response_always,response_when,response_when_keyword_in_last_message,clear_rules,ask,ask_stream,__repr__
+    :members: __init__,__setattr__,__delattr__,stream_wps,rules_count,with_stream_wps,response_always,response_when,response_when_keyword_in_last_message,response_sequence,clear_rules,ask,ask_stream,__repr__
 
 

--- a/docs/source/api_doc/model/task.rst
+++ b/docs/source/api_doc/model/task.rst
@@ -10,6 +10,6 @@ LLMTask
 -----------------------------------------------------
 
 .. autoclass:: LLMTask
-    :members: __init__,ask,ask_stream
+    :members: __init__,ask,ask_stream,__eq__,__hash__
 
 

--- a/docs/source/api_doc/response/datamodel.rst
+++ b/docs/source/api_doc/response/datamodel.rst
@@ -1,0 +1,8 @@
+hbllmutils.response.datamodel
+========================================================
+
+.. currentmodule:: hbllmutils.response.datamodel
+
+.. automodule:: hbllmutils.response.datamodel
+
+

--- a/docs/source/api_doc/response/datamodel.rst
+++ b/docs/source/api_doc/response/datamodel.rst
@@ -6,3 +6,9 @@ hbllmutils.response.datamodel
 .. automodule:: hbllmutils.response.datamodel
 
 
+create\_datamodel\_task
+-----------------------------------------------------
+
+.. autofunction:: create_datamodel_task
+
+

--- a/docs/source/api_doc/response/datamodel.rst
+++ b/docs/source/api_doc/response/datamodel.rst
@@ -6,6 +6,13 @@ hbllmutils.response.datamodel
 .. automodule:: hbllmutils.response.datamodel
 
 
+DataModelLLMTask
+-----------------------------------------------------
+
+.. autoclass:: DataModelLLMTask
+    :members: __init__
+
+
 create\_datamodel\_task
 -----------------------------------------------------
 

--- a/docs/source/api_doc/response/index.rst
+++ b/docs/source/api_doc/response/index.rst
@@ -10,5 +10,6 @@ hbllmutils.response
     :maxdepth: 3
 
     code
+    datamodel
     parsable
 

--- a/hbllmutils/history/history.py
+++ b/hbllmutils/history/history.py
@@ -8,7 +8,6 @@ It includes functionality for:
 
 The module supports multiple content types including strings, PIL Images, and lists of mixed content.
 """
-import copy
 from collections.abc import Sequence
 from typing import Union, List, Optional
 
@@ -71,6 +70,8 @@ def create_llm_message(message: LLMContentTyping, role: LLMRoleTyping = 'user') 
     }
 
 
+# Notice: LLMHistory is an immutable object
+#         Any operation will cause a new object creation.
 class LLMHistory(Sequence):
     """
     A sequence-like container for managing LLM conversation history.
@@ -142,8 +143,7 @@ class LLMHistory(Sequence):
             >>> history = LLMHistory()
             >>> history.append('user', 'Hello!')
         """
-        self._history.append(create_llm_message(message=message, role=role))
-        return self
+        return LLMHistory(history=[*self._history, create_llm_message(message=message, role=role)])
 
     def append_user(self, message: LLMContentTyping) -> 'LLMHistory':
         """
@@ -203,10 +203,9 @@ class LLMHistory(Sequence):
         """
         message = create_llm_message(message=message, role='system')
         if self._history and self._history[0]['role'] == 'system':
-            self._history[0] = message
+            return LLMHistory(history=[message, *self._history[1:]])
         else:
-            self._history.insert(0, message)
-        return self
+            return LLMHistory(history=[message, *self._history])
 
     def to_json(self) -> List[dict]:
         """
@@ -244,4 +243,4 @@ class LLMHistory(Sequence):
             >>> len(cloned)
             2
         """
-        return LLMHistory(history=copy.deepcopy(self._history))
+        return LLMHistory(history=self._history)

--- a/hbllmutils/history/history.py
+++ b/hbllmutils/history/history.py
@@ -261,3 +261,69 @@ class LLMHistory(Sequence):
             2
         """
         return LLMHistory(history=copy.deepcopy(self._history))
+
+    def __hash__(self) -> int:
+        """
+        Generate a hash value for the LLMHistory instance.
+
+        The hash is computed based on the message history content, allowing
+        LLMHistory instances to be used as dictionary keys or in sets.
+
+        :return: Hash value of the history.
+        :rtype: int
+
+        Example::
+            >>> history1 = LLMHistory().with_user_message('Hello!')
+            >>> history2 = LLMHistory().with_user_message('Hello!')
+            >>> hash(history1) == hash(history2)
+            True
+            >>> history_set = {history1, history2}
+            >>> len(history_set)
+            1
+        """
+
+        def _make_hashable(obj):
+            """
+            Recursively convert nested data structures to hashable types.
+
+            :param obj: Object to convert (dict, list, or primitive type)
+            :return: Hashable representation of the object
+            """
+            if isinstance(obj, dict):
+                # Convert dict to sorted tuple of key-value pairs
+                return tuple(sorted((k, _make_hashable(v)) for k, v in obj.items()))
+            elif isinstance(obj, (list, tuple)):
+                # Convert list/tuple to tuple of hashable elements
+                return tuple(_make_hashable(item) for item in obj)
+            elif isinstance(obj, (str, int, float, bool, type(None))):
+                # Primitive types are already hashable
+                return obj
+            else:
+                # For other types (like custom objects), convert to string
+                return str(obj)
+
+        # Convert the entire history to a hashable structure
+        hashable_history = _make_hashable(self._history)
+        return hash(hashable_history)
+
+    def __eq__(self, other) -> bool:
+        """
+        Check equality between LLMHistory instances.
+
+        Two LLMHistory instances are considered equal if they have the same
+        message history content.
+
+        :param other: Another LLMHistory instance to compare with.
+        :type other: LLMHistory
+        :return: True if histories are equal, False otherwise.
+        :rtype: bool
+
+        Example::
+            >>> history1 = LLMHistory().with_user_message('Hello!')
+            >>> history2 = LLMHistory().with_user_message('Hello!')
+            >>> history1 == history2
+            True
+        """
+        if not isinstance(other, LLMHistory):
+            return False
+        return self._history == other._history

--- a/hbllmutils/history/history.py
+++ b/hbllmutils/history/history.py
@@ -8,6 +8,7 @@ It includes functionality for:
 
 The module supports multiple content types including strings, PIL Images, and lists of mixed content.
 """
+import copy
 from collections.abc import Sequence
 from typing import Union, List, Optional
 
@@ -117,7 +118,7 @@ class LLMHistory(Sequence):
         if isinstance(result, list):
             return LLMHistory(result)
         else:
-            return result
+            return copy.deepcopy(result)
 
     def __len__(self) -> int:
         """
@@ -157,7 +158,7 @@ class LLMHistory(Sequence):
         """
         Append a user message to the history.
 
-        This is a convenience method equivalent to calling append with role='user'.
+        This is a convenience method equivalent to calling with_message with role='user'.
         Creates a new LLMHistory instance with the appended message.
 
         :param message: The message content.
@@ -178,7 +179,7 @@ class LLMHistory(Sequence):
         """
         Append an assistant message to the history.
 
-        This is a convenience method equivalent to calling append with role='assistant'.
+        This is a convenience method equivalent to calling with_message with role='assistant'.
         Creates a new LLMHistory instance with the appended message.
 
         :param message: The message content.
@@ -236,7 +237,7 @@ class LLMHistory(Sequence):
             >>> history.to_json()
             [{'role': 'user', 'content': 'Hello!'}]
         """
-        return self._history
+        return copy.deepcopy(self._history)
 
     def clone(self) -> 'LLMHistory':
         """
@@ -259,4 +260,4 @@ class LLMHistory(Sequence):
             >>> len(cloned)
             2
         """
-        return LLMHistory(history=self._history)
+        return LLMHistory(history=copy.deepcopy(self._history))

--- a/hbllmutils/history/history.py
+++ b/hbllmutils/history/history.py
@@ -5,8 +5,11 @@ It includes functionality for:
 - Creating LLM messages with various content types (text, images, or mixed)
 - Managing conversation history with role-based messages
 - Converting between different message formats
+- Serializing and deserializing conversation histories to/from JSON and YAML formats
 
 The module supports multiple content types including strings, PIL Images, and lists of mixed content.
+It provides an immutable sequence-like container for managing conversation history with support for
+different roles (user, assistant, system, tool, function).
 """
 import copy
 import json
@@ -33,7 +36,11 @@ def create_llm_message(message: LLMContentTyping, role: LLMRoleTyping = 'user') 
     Create a structured LLM message from various content types.
 
     This function converts different types of message content (text, images, or mixed)
-    into a standardized dictionary format suitable for LLM APIs.
+    into a standardized dictionary format suitable for LLM APIs. The function handles:
+    
+    - Plain text strings: Returned as-is in the content field
+    - PIL Images: Converted to blob URLs and wrapped in image_url format
+    - Lists of mixed content: Each item is converted to appropriate format (text or image_url)
 
     :param message: The message content, which can be a string, PIL Image, or list of strings/images.
     :type message: LLMContentTyping
@@ -80,7 +87,18 @@ class LLMHistory(Sequence):
 
     This class provides methods to build and maintain a conversation history
     with different roles (user, assistant, system, etc.). It implements the
-    Sequence protocol, allowing indexing and iteration.
+    Sequence protocol, allowing indexing and iteration. The class is designed
+    to be immutable - all modification operations return new instances rather
+    than modifying the existing one.
+
+    The class supports:
+    
+    - Adding messages with specific roles (user, assistant, system, etc.)
+    - Setting and updating system prompts
+    - Serialization to JSON and YAML formats
+    - Deserialization from JSON and YAML files
+    - Sequence operations (indexing, slicing, iteration, length)
+    - Hashing and equality comparison
 
     .. note::
         LLMHistory is an immutable object. Any operation will cause a new object creation.
@@ -103,6 +121,7 @@ class LLMHistory(Sequence):
         Initialize the LLMHistory instance.
 
         :param history: Optional initial history as a list of message dictionaries.
+                       Each dictionary should contain 'role' and 'content' keys.
         :type history: Optional[List[dict]]
         """
         self._history = list(history or [])
@@ -111,11 +130,22 @@ class LLMHistory(Sequence):
         """
         Get an item or slice from the history.
 
+        When indexing with a single integer, returns a deep copy of the message
+        dictionary at that position. When slicing, returns a new LLMHistory instance
+        containing the sliced messages.
+
         :param index: The index or slice to retrieve.
         :type index: int or slice
 
-        :return: A single message dict or a new LLMHistory instance for slices.
+        :return: A single message dict (deep copy) or a new LLMHistory instance for slices.
         :rtype: dict or LLMHistory
+
+        Example::
+            >>> history = LLMHistory().with_user_message("Hello!")
+            >>> history[0]
+            {'role': 'user', 'content': 'Hello!'}
+            >>> history[0:1]
+            <LLMHistory object with 1 message>
         """
         result = self._history[index]
         if isinstance(result, list):
@@ -129,6 +159,14 @@ class LLMHistory(Sequence):
 
         :return: The number of messages.
         :rtype: int
+
+        Example::
+            >>> history = LLMHistory()
+            >>> len(history)
+            0
+            >>> history = history.with_user_message("Hello!")
+            >>> len(history)
+            1
         """
         return len(self._history)
 
@@ -137,7 +175,8 @@ class LLMHistory(Sequence):
         Append a message with a specific role to the history.
 
         This method creates a new LLMHistory instance with the appended message,
-        leaving the original instance unchanged.
+        leaving the original instance unchanged. The message content is processed
+        through create_llm_message() to ensure proper formatting.
 
         :param role: The role of the message sender.
         :type role: LLMRoleTyping
@@ -207,6 +246,9 @@ class LLMHistory(Sequence):
         it will be replaced. Otherwise, the new system message will be inserted
         at the start of the history. This method creates a new LLMHistory instance.
 
+        System prompts are typically used to set the behavior or context for the
+        LLM at the start of a conversation.
+
         :param message: The system prompt content.
         :type message: LLMContentTyping
 
@@ -230,6 +272,9 @@ class LLMHistory(Sequence):
     def to_json(self) -> List[dict]:
         """
         Convert the history to a JSON-serializable list of dictionaries.
+
+        Returns a deep copy of the internal message history, ensuring that
+        modifications to the returned list do not affect the original history.
 
         :return: A list of message dictionaries.
         :rtype: List[dict]
@@ -270,7 +315,9 @@ class LLMHistory(Sequence):
         Generate a hash value for the LLMHistory instance.
 
         The hash is computed based on the message history content, allowing
-        LLMHistory instances to be used as dictionary keys or in sets.
+        LLMHistory instances to be used as dictionary keys or in sets. The
+        hash is computed by recursively converting nested data structures
+        (dicts, lists) to hashable types (tuples).
 
         :return: Hash value of the history.
         :rtype: int
@@ -289,8 +336,15 @@ class LLMHistory(Sequence):
             """
             Recursively convert nested data structures to hashable types.
 
+            Converts dictionaries to sorted tuples of key-value pairs,
+            lists/tuples to tuples of hashable elements, and handles
+            primitive types directly. For other types, converts to string.
+
             :param obj: Object to convert (dict, list, or primitive type)
+            :type obj: Any
+
             :return: Hashable representation of the object
+            :rtype: tuple or str or int or float or bool or None
             """
             if isinstance(obj, dict):
                 # Convert dict to sorted tuple of key-value pairs
@@ -314,10 +368,12 @@ class LLMHistory(Sequence):
         Check equality between LLMHistory instances.
 
         Two LLMHistory instances are considered equal if they have the same
-        message history content.
+        message history content. Returns False if the other object is not
+        an LLMHistory instance.
 
         :param other: Another LLMHistory instance to compare with.
         :type other: LLMHistory
+
         :return: True if histories are equal, False otherwise.
         :rtype: bool
 
@@ -335,9 +391,15 @@ class LLMHistory(Sequence):
         """
         Export the history to a JSON file.
 
+        Saves the conversation history to a JSON file with configurable formatting.
+        The parent directory will be created if it doesn't exist. Default parameters
+        provide pretty-printed output with 2-space indentation, UTF-8 encoding,
+        and sorted keys.
+
         :param file: The file path to save the JSON data.
         :type file: str
         :param params: Additional parameters to pass to json.dump (e.g., indent, ensure_ascii).
+                      Default parameters: indent=2, ensure_ascii=False, sort_keys=True
 
         :raises IOError: If the file cannot be written.
 
@@ -361,6 +423,10 @@ class LLMHistory(Sequence):
     def load_json(cls, file: str) -> 'LLMHistory':
         """
         Load history from a JSON file.
+
+        Reads and validates a JSON file containing conversation history.
+        The file must contain a list of message dictionaries, where each
+        dictionary has 'role' and 'content' fields.
 
         :param file: The file path to load the JSON data from.
         :type file: str
@@ -402,9 +468,16 @@ class LLMHistory(Sequence):
         """
         Export the history to a YAML file.
 
+        Saves the conversation history to a YAML file with configurable formatting.
+        The parent directory will be created if it doesn't exist. Default parameters
+        provide human-readable output with block style, UTF-8 encoding, 2-space
+        indentation, and sorted keys.
+
         :param file: The file path to save the YAML data.
         :type file: str
         :param params: Additional parameters to pass to yaml.dump (e.g., default_flow_style, indent).
+                      Default parameters: default_flow_style=False, allow_unicode=True,
+                      indent=2, sort_keys=True
 
         :raises IOError: If the file cannot be written.
         :raises ImportError: If PyYAML is not installed.
@@ -429,6 +502,10 @@ class LLMHistory(Sequence):
     def load_yaml(cls, file: str) -> 'LLMHistory':
         """
         Load history from a YAML file.
+
+        Reads and validates a YAML file containing conversation history.
+        The file must contain a list of message dictionaries, where each
+        dictionary has 'role' and 'content' fields.
 
         :param file: The file path to load the YAML data from.
         :type file: str

--- a/hbllmutils/meta/datamodel/task.py
+++ b/hbllmutils/meta/datamodel/task.py
@@ -47,7 +47,7 @@ def create_datamodel_prompt_generation_task(
     """
     return LLMTask(
         model=model,
-        history=LLMHistory().append_user(
+        history=LLMHistory().with_user_message(
             create_meta_prompt_for_datamodel(
                 datamodel_class=datamodel_class,
                 related_datamodel_classes=related_datamodel_classes,

--- a/hbllmutils/model/base.py
+++ b/hbllmutils/model/base.py
@@ -132,3 +132,18 @@ class LLMModel(ABC):
             # Prints the story as it's generated, chunk by chunk
         """
         raise NotImplementedError  # pragma: no cover
+
+    def _params(self):
+        # must be a stable and hashable return
+        raise NotImplementedError  # pragma: no cover
+
+    def _values(self):
+        return self.__class__, self._params()
+
+    def __eq__(self, other):
+        if type(other) != type(self):
+            return False
+        return self._values() == other._values()
+
+    def __hash__(self):
+        return hash(self._values())

--- a/hbllmutils/model/base.py
+++ b/hbllmutils/model/base.py
@@ -134,16 +134,60 @@ class LLMModel(ABC):
         raise NotImplementedError  # pragma: no cover
 
     def _params(self):
-        # must be a stable and hashable return
+        """
+        Get the parameters that define this model instance.
+        
+        This method should return a stable and hashable representation of the model's
+        parameters. It is used for equality comparison and hashing of model instances.
+        The returned value must be hashable (e.g., tuple, frozenset) to support
+        the __hash__ method.
+        
+        :return: A hashable representation of the model's parameters.
+        
+        :raises NotImplementedError: This method must be implemented by subclasses.
+        """
         raise NotImplementedError  # pragma: no cover
 
     def _values(self):
+        """
+        Get the values that uniquely identify this model instance.
+        
+        This method returns a tuple containing the model's class and its parameters,
+        which together uniquely identify the model instance. This is used for
+        equality comparison and hashing.
+        
+        :return: A tuple of (class, parameters) that uniquely identifies this model.
+        :rtype: tuple
+        """
         return self.__class__, self._params()
 
     def __eq__(self, other):
+        """
+        Check equality between this model and another object.
+        
+        Two LLMModel instances are considered equal if they are of the same class
+        and have the same parameters as returned by _values().
+        
+        :param other: The object to compare with.
+        :type other: object
+        
+        :return: True if the objects are equal, False otherwise.
+        :rtype: bool
+        """
         if type(other) != type(self):
             return False
+        # noinspection PyProtectedMember,PyUnresolvedReferences
         return self._values() == other._values()
 
     def __hash__(self):
+        """
+        Get the hash value of this model instance.
+        
+        The hash is computed from the values returned by _values(), which includes
+        the model's class and parameters. This allows LLMModel instances to be used
+        as dictionary keys or in sets.
+        
+        :return: The hash value of this model instance.
+        :rtype: int
+        """
         return hash(self._values())

--- a/hbllmutils/model/fake.py
+++ b/hbllmutils/model/fake.py
@@ -11,7 +11,7 @@ The module includes:
 """
 
 import time
-from typing import List, Union, Tuple, Optional, Any, Callable
+from typing import List, Union, Tuple, Optional, Any, Callable, Generator
 
 import jieba
 
@@ -365,9 +365,13 @@ class FakeLLMModel(LLMModel):
             self,
             content: str,
             reasoning_content: Optional[str] = None
-    ):
+    ) -> Generator[Tuple[Optional[str], Optional[str]], None, None]:
         """
         Generate word-by-word chunks for streaming, with delays between words.
+
+        This method uses jieba to segment text into words and yields them one at a time,
+        with a delay calculated based on the stream_fps (words per second) setting.
+        Reasoning content is yielded first if provided, followed by the main content.
 
         :param content: The main content to stream.
         :type content: str
@@ -396,6 +400,10 @@ class FakeLLMModel(LLMModel):
     ) -> ResponseStream:
         """
         Send messages and get a streaming response.
+
+        This method returns a ResponseStream that yields the response word-by-word,
+        simulating the streaming behavior of a real LLM. The streaming speed is
+        controlled by the stream_wps parameter set during initialization.
 
         :param messages: The list of message dictionaries containing conversation history.
         :type messages: List[dict]
@@ -450,7 +458,7 @@ class FakeLLMModel(LLMModel):
         params_str = ', '.join(param_strings)
         return f"{self.__class__.__name__}({params_str})"
 
-    def _params(self):
+    def _params(self) -> tuple:
         """
         Get the parameters that define this model instance.
 

--- a/hbllmutils/model/remote.py
+++ b/hbllmutils/model/remote.py
@@ -334,3 +334,42 @@ class RemoteLLMModel(LLMModel):
 
         params_str = ', '.join(param_strings)
         return f"{self.__class__.__name__}({params_str})"
+
+    def _params(self):
+        """
+        Get the parameters that define this model instance.
+
+        This method returns a stable and hashable representation of the model's
+        parameters including all constructor arguments. It is used for equality
+        comparison and hashing of model instances.
+
+        :return: A hashable tuple representation of the model's parameters.
+        :rtype: tuple
+
+        Example::
+            >>> model = RemoteLLMModel(
+            ...     base_url="https://api.openai.com/v1",
+            ...     api_token="sk-xxx",
+            ...     model_name="gpt-3.5-turbo",
+            ...     max_tokens=1000
+            ... )
+            >>> params = model._params()
+            >>> isinstance(params, tuple)
+            True
+        """
+        # Convert headers dict to sorted tuple of tuples for hashability
+        headers_tuple = tuple(sorted(self.headers.items())) if self.headers else ()
+
+        # Convert default_params dict to sorted tuple of tuples for hashability
+        default_params_tuple = tuple(sorted(self.default_params.items())) if self.default_params else ()
+
+        return (
+            self.base_url,
+            self.api_token,
+            self.model_name,
+            self.organization_id,
+            self.timeout,
+            self.max_retries,
+            headers_tuple,
+            default_params_tuple
+        )

--- a/hbllmutils/model/task.py
+++ b/hbllmutils/model/task.py
@@ -7,7 +7,7 @@ maintaining conversation history.
 """
 import logging
 from abc import ABC
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, Any
 
 from .base import LLMModel
 from .stream import ResponseStream
@@ -116,3 +116,63 @@ class LLMTask(ABC):
             with_reasoning=with_reasoning,
             **params,
         )
+
+    def _params(self) -> Tuple[LLMModel, LLMHistory]:
+        """
+        Get the parameters of this LLMTask instance.
+
+        :return: A tuple containing the model and history.
+        :rtype: Tuple[LLMModel, LLMHistory]
+        """
+        return self.model, self.history
+
+    def _values(self) -> Tuple[type, Any]:
+        """
+        Get the class type and parameters of this LLMTask instance.
+
+        This method is used for equality comparison and hashing.
+
+        :return: A tuple containing the class type and the parameters tuple.
+        :rtype: Tuple[type, Any]
+        """
+        return self.__class__, self._params()
+
+    def __eq__(self, other) -> bool:
+        """
+        Check equality between this LLMTask and another object.
+
+        Two LLMTask instances are considered equal if they have the same class type
+        and the same model and history parameters.
+
+        :param other: The object to compare with.
+        :type other: object
+
+        :return: True if the objects are equal, False otherwise.
+        :rtype: bool
+
+        Example::
+            >>> task1 = LLMTask(model, history)
+            >>> task2 = LLMTask(model, history)
+            >>> task1 == task2
+            True
+        """
+        if type(other) != type(self):
+            return False
+        # noinspection PyProtectedMember,PyUnresolvedReferences
+        return self._values() == other._values()
+
+    def __hash__(self) -> int:
+        """
+        Get the hash value of this LLMTask instance.
+
+        The hash is computed based on the class type and the model and history parameters.
+
+        :return: The hash value.
+        :rtype: int
+
+        Example::
+            >>> task = LLMTask(model, history)
+            >>> hash(task)
+            1234567890
+        """
+        return hash(self._values())

--- a/hbllmutils/response/__init__.py
+++ b/hbllmutils/response/__init__.py
@@ -19,4 +19,5 @@ Main exports:
 """
 
 from .code import extract_code, parse_json
+from .datamodel import create_datamodel_task
 from .parsable import OutputParseWithException, OutputParseFailed, ParsableLLMTask

--- a/hbllmutils/response/datamodel.py
+++ b/hbllmutils/response/datamodel.py
@@ -1,15 +1,22 @@
 """
-This module provides functionality for creating and managing LLM tasks that work with structured data models.
+Data model-based LLM task module.
 
-It includes classes and functions for:
-- Creating LLM tasks that parse and validate responses against data models
-- Generating format prompts for data models
-- Managing task requirements and validation logic
+This module provides functionality for creating and managing LLM tasks that parse and validate
+responses against structured data models. It supports both Pydantic models and dataclasses,
+with automatic prompt generation and validation capabilities.
 
-The main components are:
-- DataModelLLMTask: A task class that handles parsing and validation of LLM responses
-- create_datamodel_task: Factory function for creating data model tasks with proper configuration
+Key Features:
+    - Structured data validation using Pydantic or dataclasses
+    - Automatic format prompt generation
+    - Sample-based learning support
+    - Retry mechanism for failed validations
+    - JSON parsing and validation
+
+Main Components:
+    - DataModelLLMTask: Core task class for model-based validation
+    - create_datamodel_task: Factory function for creating configured tasks
 """
+
 import dataclasses
 import io
 import json
@@ -86,7 +93,7 @@ class DataModelLLMTask(ParsableLLMTask):
 
 
 @lru_cache()
-def _ask_for_format_prompt(pg_task: LLMTask):
+def _ask_for_format_prompt(pg_task: LLMTask) -> str:
     """
     Get the format prompt from a prompt generation task with caching.
     
@@ -110,7 +117,7 @@ def _get_format_prompt(
         datamodel_class: type,
         prompt_generation_model: LLMModel,
         related_datamodel_classes: Optional[List[type]] = None,
-):
+) -> str:
     """
     Generate a format prompt for a given data model class.
     
@@ -150,7 +157,7 @@ def create_datamodel_task(
         prompt_generation_model: Optional[LLMModel] = None,
         fn_parse_and_validate: Optional[Callable[[Any], Any]] = None,
         fn_dump_json: Optional[Callable[[Any], Any]] = None,
-):
+) -> DataModelLLMTask:
     """
     Create a DataModelLLMTask with configured prompts and validation.
     

--- a/hbllmutils/response/datamodel.py
+++ b/hbllmutils/response/datamodel.py
@@ -1,3 +1,16 @@
+"""
+This module provides functionality for creating and managing LLM tasks that work with structured data models.
+
+It includes classes and functions for:
+- Creating LLM tasks that parse and validate responses against data models
+- Generating format prompts for data models
+- Managing task requirements and validation logic
+
+The main components are:
+- DataModelLLMTask: A task class that handles parsing and validation of LLM responses
+- create_datamodel_task: Factory function for creating data model tasks with proper configuration
+"""
+
 import json
 import textwrap
 from functools import lru_cache
@@ -13,8 +26,34 @@ from ..model import LLMModel, LLMTask
 
 
 class DataModelLLMTask(ParsableLLMTask):
+    """
+    A specialized LLM task that parses and validates responses against a data model.
+    
+    This class extends ParsableLLMTask to provide structured data validation
+    using a custom parsing and validation function.
+    """
+
     def __init__(self, model: LLMModel, history: LLMHistory,
                  fn_parse_and_validate: Callable[[Any], Any], default_max_retries: int = 5):
+        """
+        Initialize a DataModelLLMTask instance.
+        
+        :param model: The LLM model to use for generating responses.
+        :type model: LLMModel
+        :param history: The conversation history to maintain context.
+        :type history: LLMHistory
+        :param fn_parse_and_validate: Function to parse and validate the response data.
+        :type fn_parse_and_validate: Callable[[Any], Any]
+        :param default_max_retries: Maximum number of retries for failed attempts, defaults to 5.
+        :type default_max_retries: int
+        
+        Example::
+            >>> task = DataModelLLMTask(
+            ...     model=my_model,
+            ...     history=my_history,
+            ...     fn_parse_and_validate=MyModel.model_validate
+            ... )
+        """
         super().__init__(
             model=model,
             history=history,
@@ -23,11 +62,45 @@ class DataModelLLMTask(ParsableLLMTask):
         self._fn_parse_and_validate = fn_parse_and_validate
 
     def _parse_and_validate(self, content: str):
+        """
+        Parse and validate the content from LLM response.
+        
+        This method extracts code from the content, parses it as JSON,
+        and validates it using the configured validation function.
+        
+        :param content: The raw content string from LLM response.
+        :type content: str
+        
+        :return: The validated data object.
+        :rtype: Any
+        :raises json.JSONDecodeError: If the content cannot be parsed as JSON.
+        :raises ValidationError: If the parsed data fails validation.
+        
+        Example::
+            >>> task._parse_and_validate('```json\\n{"name": "test"}\\n```')
+            MyModel(name='test')
+        """
         return self._fn_parse_and_validate(json.loads(extract_code(content)))
 
 
 @lru_cache()
 def _ask_for_format_prompt(pg_task: LLMTask):
+    """
+    Get the format prompt from a prompt generation task with caching.
+    
+    This function is cached to avoid regenerating the same format prompt
+    multiple times for the same task.
+    
+    :param pg_task: The prompt generation task to execute.
+    :type pg_task: LLMTask
+    
+    :return: The generated format prompt string.
+    :rtype: str
+    
+    Example::
+        >>> prompt = _ask_for_format_prompt(my_pg_task)
+        >>> # Subsequent calls with the same task return cached result
+    """
     return pg_task.ask()
 
 
@@ -36,6 +109,28 @@ def _get_format_prompt(
         prompt_generation_model: LLMModel,
         related_datamodel_classes: Optional[List[type]] = None,
 ):
+    """
+    Generate a format prompt for a given data model class.
+    
+    This function creates a prompt generation task and retrieves the format
+    prompt that describes how to structure data according to the model.
+    
+    :param datamodel_class: The data model class to generate format prompt for.
+    :type datamodel_class: type
+    :param prompt_generation_model: The LLM model to use for prompt generation.
+    :type prompt_generation_model: LLMModel
+    :param related_datamodel_classes: Optional list of related data model classes, defaults to None.
+    :type related_datamodel_classes: Optional[List[type]]
+    
+    :return: The generated format prompt string.
+    :rtype: str
+    
+    Example::
+        >>> format_prompt = _get_format_prompt(
+        ...     datamodel_class=MyModel,
+        ...     prompt_generation_model=my_model
+        ... )
+    """
     pg_task = create_datamodel_prompt_generation_task(
         model=prompt_generation_model,
         datamodel_class=datamodel_class,
@@ -52,6 +147,42 @@ def create_datamodel_task(
         prompt_generation_model: Optional[LLMModel] = None,
         fn_parse_and_validate: Optional[Callable[[Any], Any]] = None,
 ):
+    """
+    Create a DataModelLLMTask with configured prompts and validation.
+    
+    This factory function sets up a complete LLM task that:
+    - Generates format prompts based on the data model
+    - Configures task requirements
+    - Sets up parsing and validation logic
+    
+    :param model: The LLM model to use for the main task.
+    :type model: LLMModel
+    :param datamodel_class: The data model class that defines the expected output structure.
+    :type datamodel_class: type
+    :param task_requirements: Description of what the task should accomplish.
+    :type task_requirements: str
+    :param related_datamodel_classes: Optional list of related data model classes for context, defaults to None.
+    :type related_datamodel_classes: Optional[List[type]]
+    :param prompt_generation_model: Optional separate model for prompt generation, defaults to None (uses main model).
+    :type prompt_generation_model: Optional[LLMModel]
+    :param fn_parse_and_validate: Optional custom parsing and validation function, defaults to None.
+    :type fn_parse_and_validate: Optional[Callable[[Any], Any]]
+    
+    :return: A configured DataModelLLMTask instance.
+    :rtype: DataModelLLMTask
+    :raises ValueError: If datamodel_class is not a pydantic BaseModel subclass and fn_parse_and_validate is not provided.
+    
+    Example::
+        >>> task = create_datamodel_task(
+        ...     model=my_model,
+        ...     datamodel_class=MyModel,
+        ...     task_requirements="Extract user information from the text",
+        ...     related_datamodel_classes=[AddressModel]
+        ... )
+        >>> result = task.ask("John Doe lives at 123 Main St")
+        >>> isinstance(result, MyModel)
+        True
+    """
     format_prompt = textwrap.dedent(_get_format_prompt(
         datamodel_class=datamodel_class,
         related_datamodel_classes=related_datamodel_classes,

--- a/hbllmutils/response/datamodel.py
+++ b/hbllmutils/response/datamodel.py
@@ -1,0 +1,53 @@
+import textwrap
+from functools import lru_cache
+from typing import Optional, List
+
+from ..history import LLMHistory
+from ..meta import create_datamodel_prompt_generation_task
+from ..model import LLMModel, LLMTask
+
+
+@lru_cache()
+def _ask_for_format_prompt(pg_task: LLMTask):
+    return pg_task.ask()
+
+
+def _get_format_prompt(
+        datamodel_class: type,
+        prompt_generation_model: LLMModel,
+        related_datamodel_classes: Optional[List[type]] = None,
+):
+    pg_task = create_datamodel_prompt_generation_task(
+        model=prompt_generation_model,
+        datamodel_class=datamodel_class,
+        related_datamodel_classes=related_datamodel_classes,
+    )
+    return _ask_for_format_prompt(pg_task)
+
+
+def create_datamodel_task(
+        model: LLMModel,
+        datamodel_class: type,
+        task_requirements: str,
+        related_datamodel_classes: Optional[List[type]] = None,
+        prompt_generation_model: Optional[LLMModel] = None,
+):
+    format_prompt = _get_format_prompt(
+        datamodel_class=datamodel_class,
+        related_datamodel_classes=related_datamodel_classes,
+        prompt_generation_model=prompt_generation_model or model,
+    )
+
+    system_prompt = textwrap.dedent(f"""
+{task_requirements}
+
+# Output guide
+
+{format_prompt}
+    """).strip()
+
+    history = LLMHistory().with_system_prompt(system_prompt)
+    return LLMTask(
+        model=model,
+        history=history,
+    )

--- a/hbllmutils/response/datamodel.py
+++ b/hbllmutils/response/datamodel.py
@@ -158,6 +158,7 @@ def create_datamodel_task(
     - Generates format prompts based on the data model
     - Configures task requirements
     - Sets up parsing and validation logic
+    - Optionally includes sample inputs and outputs for reference
     
     :param model: The LLM model to use for the main task.
     :type model: LLMModel
@@ -165,22 +166,30 @@ def create_datamodel_task(
     :type datamodel_class: type
     :param task_requirements: Description of what the task should accomplish.
     :type task_requirements: str
+    :param samples: Optional list of (input, output) tuples to provide as examples, defaults to None.
+    :type samples: Optional[List[Tuple[str, Any]]]
     :param related_datamodel_classes: Optional list of related data model classes for context, defaults to None.
     :type related_datamodel_classes: Optional[List[type]]
     :param prompt_generation_model: Optional separate model for prompt generation, defaults to None (uses main model).
     :type prompt_generation_model: Optional[LLMModel]
     :param fn_parse_and_validate: Optional custom parsing and validation function, defaults to None.
     :type fn_parse_and_validate: Optional[Callable[[Any], Any]]
+    :param fn_dump_json: Optional custom function to convert data model instances to JSON-serializable dicts, defaults to None.
+    :type fn_dump_json: Optional[Callable[[Any], Any]]
     
     :return: A configured DataModelLLMTask instance.
     :rtype: DataModelLLMTask
     :raises ValueError: If datamodel_class is not a pydantic BaseModel subclass and fn_parse_and_validate is not provided.
+    :raises ValueError: If samples are provided but datamodel_class is not a pydantic BaseModel or dataclass and fn_dump_json is not provided.
     
     Example::
         >>> task = create_datamodel_task(
-        ...     model=my_model,
+        ...     model=my_llm_model,
         ...     datamodel_class=MyModel,
         ...     task_requirements="Extract user information from the text",
+        ...     samples=[
+        ...         ("John Doe, age 30", MyModel(name="John Doe", age=30)),
+        ...     ],
         ...     related_datamodel_classes=[AddressModel]
         ... )
         >>> result = task.ask("John Doe lives at 123 Main St")

--- a/hbllmutils/response/parsable.py
+++ b/hbllmutils/response/parsable.py
@@ -152,7 +152,7 @@ class ParsableLLMTask(LLMTask):
         """
         raise NotImplementedError  # pragma: no cover
 
-    def ask_then_parse(self, with_reasoning: bool = False, max_retries: Optional[int] = None, **params):
+    def ask_then_parse(self, input_content: Optional[str] = None, max_retries: Optional[int] = None, **params):
         """
         Ask the model a question and parse the response with automatic retry on parse failure.
 
@@ -164,15 +164,14 @@ class ParsableLLMTask(LLMTask):
         The method uses the _parse_and_validate method to parse outputs and will catch
         exceptions specified in __exceptions__. Other exceptions will propagate immediately.
 
-        :param with_reasoning: Whether to include reasoning in the response. If True, returns
-                              a tuple of (reasoning, parsed_output). Defaults to False.
-        :type with_reasoning: bool
+        :param input_content: Optional user input content to add to the history before asking.
+                             If None, uses the existing history without modification.
+        :type input_content: Optional[str]
         :param max_retries: Maximum number of retry attempts. If None, uses default_max_retries.
                            Must be a positive integer if provided.
         :type max_retries: Optional[int]
         :param params: Additional parameters to pass to the ask method (e.g., prompt, temperature).
-        :return: The successfully parsed output. Return type depends on _parse_and_validate
-                implementation. If with_reasoning is True, returns tuple of (reasoning, parsed_output).
+        :return: The successfully parsed output from the model.
         :raises OutputParseFailed: If parsing fails after all retry attempts. The exception
                                   contains all failed attempts in its tries attribute.
         :raises Exception: Any exception not matching __exceptions__ will propagate immediately.
@@ -180,17 +179,15 @@ class ParsableLLMTask(LLMTask):
         Example::
             >>> task = ParsableLLMTask(model)
             >>> # Simple usage
-            >>> result = task.ask_then_parse(prompt="What is 2+2?", max_retries=3)
+            >>> result = task.ask_then_parse(input_content="What is 2+2?", max_retries=3)
             >>> print(result)
             4
             >>> 
             >>> # With reasoning
-            >>> reasoning, result = task.ask_then_parse(
-            ...     prompt="Solve this problem",
-            ...     with_reasoning=True,
+            >>> result = task.ask_then_parse(
+            ...     input_content="Solve this problem",
             ...     max_retries=2
             ... )
-            >>> print(f"Reasoning: {reasoning}")
             >>> print(f"Result: {result}")
         """
         if max_retries is None:
@@ -199,11 +196,7 @@ class ParsableLLMTask(LLMTask):
         tries = 0
         err_tries = []
         while tries < max_retries:
-            if with_reasoning:
-                _, content = self.ask(with_reasoning=with_reasoning, **params)
-            else:
-                content = self.ask(with_reasoning=with_reasoning, **params)
-
+            content = self.ask(input_content=input_content, **params)
             try:
                 parsed_output = self._parse_and_validate(content)
             except self.__exceptions__ as err:

--- a/hbllmutils/response/parsable.py
+++ b/hbllmutils/response/parsable.py
@@ -182,13 +182,6 @@ class ParsableLLMTask(LLMTask):
             >>> result = task.ask_then_parse(input_content="What is 2+2?", max_retries=3)
             >>> print(result)
             4
-            >>> 
-            >>> # With reasoning
-            >>> result = task.ask_then_parse(
-            ...     input_content="Solve this problem",
-            ...     max_retries=2
-            ... )
-            >>> print(f"Result: {result}")
         """
         if max_retries is None:
             max_retries = self.default_max_retries

--- a/hbllmutils/testing/alive.py
+++ b/hbllmutils/testing/alive.py
@@ -57,7 +57,7 @@ class _HelloTest(BinaryTest):
             'Hello! How can I help you today?'
         """
         content = model.ask(
-            messages=LLMHistory().append_user('hello!').to_json(),
+            messages=LLMHistory().with_user_message('hello!').to_json(),
             **params,
         )
         return BinaryTestResult(
@@ -135,7 +135,7 @@ class _PingTest(BinaryTest):
             'Pong!'
         """
         content = model.ask(
-            messages=LLMHistory().append_user('ping!').to_json(),
+            messages=LLMHistory().with_user_message('ping!').to_json(),
             **params,
         )
         return BinaryTestResult(

--- a/test/history/test_history.py
+++ b/test/history/test_history.py
@@ -130,7 +130,7 @@ class TestHistoryHistoryModule:
 
     def test_append_with_string(self, mock_to_blob_url):
         history = LLMHistory()
-        new_history = history.append("user", "Hello")
+        new_history = history.with_message("user", "Hello")
         assert len(new_history) == 1
         assert new_history[0]["role"] == "user"
         assert new_history[0]["content"] == "Hello"
@@ -139,7 +139,7 @@ class TestHistoryHistoryModule:
 
     def test_append_with_image(self, mock_image, mock_to_blob_url):
         history = LLMHistory()
-        new_history = history.append("user", mock_image)
+        new_history = history.with_message("user", mock_image)
         assert len(new_history) == 1
         assert new_history[0]["role"] == "user"
         assert new_history[0]["content"] == [{"type": "image_url", "image_url": "blob:mock_url"}]
@@ -148,7 +148,7 @@ class TestHistoryHistoryModule:
 
     def test_append_user(self, mock_to_blob_url):
         history = LLMHistory()
-        new_history = history.append_user("Hello user")
+        new_history = history.with_user_message("Hello user")
         assert len(new_history) == 1
         assert new_history[0]["role"] == "user"
         assert new_history[0]["content"] == "Hello user"
@@ -157,7 +157,7 @@ class TestHistoryHistoryModule:
 
     def test_append_assistant(self, mock_to_blob_url):
         history = LLMHistory()
-        new_history = history.append_assistant("Hello assistant")
+        new_history = history.with_assistant_message("Hello assistant")
         assert len(new_history) == 1
         assert new_history[0]["role"] == "assistant"
         assert new_history[0]["content"] == "Hello assistant"
@@ -166,7 +166,7 @@ class TestHistoryHistoryModule:
 
     def test_set_system_prompt_empty_history(self, mock_to_blob_url):
         history = LLMHistory()
-        new_history = history.set_system_prompt("System message")
+        new_history = history.with_system_prompt("System message")
         assert len(new_history) == 1
         assert new_history[0]["role"] == "system"
         assert new_history[0]["content"] == "System message"
@@ -175,7 +175,7 @@ class TestHistoryHistoryModule:
 
     def test_set_system_prompt_replace_existing(self, mock_to_blob_url):
         history = LLMHistory([{"role": "system", "content": "Old system"}])
-        new_history = history.set_system_prompt("New system")
+        new_history = history.with_system_prompt("New system")
         assert len(new_history) == 1
         assert new_history[0]["role"] == "system"
         assert new_history[0]["content"] == "New system"
@@ -184,7 +184,7 @@ class TestHistoryHistoryModule:
 
     def test_set_system_prompt_insert_at_beginning(self, mock_to_blob_url):
         history = LLMHistory([{"role": "user", "content": "Hello"}])
-        new_history = history.set_system_prompt("System message")
+        new_history = history.with_system_prompt("System message")
         assert len(new_history) == 2
         assert new_history[0]["role"] == "system"
         assert new_history[0]["content"] == "System message"
@@ -217,14 +217,14 @@ class TestHistoryHistoryModule:
 
     def test_clone_independence(self, mock_to_blob_url):
         history = LLMHistory()
-        history_with_msg = history.append_user("Original message")
+        history_with_msg = history.with_user_message("Original message")
         cloned = history_with_msg.clone()
 
         # Modify original
-        new_history = history_with_msg.append_user("New message in original")
+        new_history = history_with_msg.with_user_message("New message in original")
 
         # Modify clone
-        new_cloned = cloned.append_assistant("New message in clone")
+        new_cloned = cloned.with_assistant_message("New message in clone")
 
         # Verify independence
         assert len(new_history) == 2
@@ -238,9 +238,9 @@ class TestHistoryHistoryModule:
     def test_method_chaining(self, mock_to_blob_url):
         history = LLMHistory()
         result = (history
-                  .set_system_prompt("You are helpful")
-                  .append_user("Hello")
-                  .append_assistant("Hi there"))
+                  .with_system_prompt("You are helpful")
+                  .with_user_message("Hello")
+                  .with_assistant_message("Hi there"))
 
         assert len(result) == 3
         assert result[0]["role"] == "system"
@@ -253,9 +253,9 @@ class TestHistoryHistoryModule:
         history = LLMHistory()
 
         # Test that all operations return new instances
-        h1 = history.append_user("msg1")
-        h2 = history.append_assistant("msg2")
-        h3 = history.set_system_prompt("system")
+        h1 = history.with_user_message("msg1")
+        h2 = history.with_assistant_message("msg2")
+        h3 = history.with_system_prompt("system")
 
         # All should be different instances
         assert h1 is not history

--- a/test/history/test_history.py
+++ b/test/history/test_history.py
@@ -197,7 +197,7 @@ class TestHistoryHistoryModule:
         history = LLMHistory(sample_history)
         result = history.to_json()
         assert result == sample_history
-        assert result is history._history
+        assert result is not history._history
 
     def test_clone_empty_history(self):
         history = LLMHistory()

--- a/test/model/test_fake.py
+++ b/test/model/test_fake.py
@@ -90,75 +90,149 @@ class TestFakeLLMModel:
         """Test FakeLLMModel initialization with default stream_wps."""
         model = FakeLLMModel()
         assert model.stream_fps == 50
-        assert model._rules == []
+        assert model.rules_count == 0
 
     def test_init_custom_stream_wps(self):
         """Test FakeLLMModel initialization with custom stream_wps."""
         model = FakeLLMModel(stream_wps=100)
         assert model.stream_fps == 100
-        assert model._rules == []
+        assert model.rules_count == 0
+
+    def test_init_with_rules(self):
+        """Test FakeLLMModel initialization with rules parameter."""
+        rules = [(_fn_always_true, "response")]
+        model = FakeLLMModel(stream_wps=50, rules=rules)
+        assert model.rules_count == 1
+        assert model._rules == tuple(rules)
+
+    def test_init_with_none_rules(self):
+        """Test FakeLLMModel initialization with None rules."""
+        model = FakeLLMModel(stream_wps=50, rules=None)
+        assert model.rules_count == 0
+        assert model._rules == tuple()
+
+    def test_immutability_setattr_after_frozen(self):
+        """Test that attributes cannot be modified after initialization."""
+        model = FakeLLMModel()
+        with pytest.raises(AttributeError, match="Cannot modify attribute '_stream_fps' of immutable FakeLLMModel"):
+            model._stream_fps = 200
+
+    def test_immutability_setattr_new_attribute(self):
+        """Test that new attributes cannot be added after initialization."""
+        model = FakeLLMModel()
+        with pytest.raises(AttributeError, match="Cannot modify attribute 'new_attr' of immutable FakeLLMModel"):
+            model.new_attr = "value"
+
+    def test_immutability_delattr(self):
+        """Test that attributes cannot be deleted."""
+        model = FakeLLMModel()
+        with pytest.raises(AttributeError, match="Cannot delete attribute '_stream_fps' of immutable FakeLLMModel"):
+            del model._stream_fps
+
+    def test_logger_name_property(self):
+        """Test _logger_name property."""
+        model = FakeLLMModel()
+        assert model._logger_name == '<faker>'
 
     def test_rules_count_property_empty(self):
         """Test rules_count property with no rules."""
         model = FakeLLMModel()
         assert model.rules_count == 0
 
-    def test_rules_count_property_with_rules(self, fake_model):
+    def test_rules_count_property_with_rules(self):
         """Test rules_count property with multiple rules."""
-        fake_model.response_always("response1")
-        fake_model.response_always("response2")
-        fake_model.response_always("response3")
-        assert fake_model.rules_count == 3
+        model = FakeLLMModel()
+        model = model.response_always("response1")
+        model = model.response_always("response2")
+        model = model.response_always("response3")
+        assert model.rules_count == 3
 
-    def test_get_response_with_string_response(self, fake_model, sample_messages):
+    def test_create_new_instance_default_params(self):
+        """Test _create_new_instance with default parameters."""
+        model = FakeLLMModel(stream_wps=100)
+        new_model = model._create_new_instance()
+
+        assert new_model is not model
+        assert new_model.stream_fps == 100
+        assert new_model.rules_count == 0
+
+    def test_create_new_instance_override_stream_wps(self):
+        """Test _create_new_instance with overridden stream_wps."""
+        model = FakeLLMModel(stream_wps=100)
+        new_model = model._create_new_instance(stream_wps=200)
+
+        assert new_model.stream_fps == 200
+
+    def test_create_new_instance_override_rules(self):
+        """Test _create_new_instance with overridden rules."""
+        model = FakeLLMModel()
+        rules = [(_fn_always_true, "response")]
+        new_model = model._create_new_instance(rules=rules)
+
+        assert new_model.rules_count == 1
+
+    def test_get_response_with_string_response(self, sample_messages):
         """Test _get_response with string response."""
-        fake_model.response_always("test response")
+        model = FakeLLMModel().response_always("test response")
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
 
         assert reasoning == ""
         assert content == "test response"
 
-    def test_get_response_with_tuple_response(self, fake_model, sample_messages):
+    def test_get_response_with_tuple_response(self, sample_messages):
         """Test _get_response with tuple response."""
-        fake_model.response_always(("reasoning", "content"))
+        model = FakeLLMModel().response_always(("reasoning", "content"))
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
 
         assert reasoning == "reasoning"
         assert content == "content"
 
-    def test_get_response_with_list_response(self, fake_model, sample_messages):
+    def test_get_response_with_list_response(self, sample_messages):
         """Test _get_response with list response."""
-        fake_model.response_always(["reasoning", "content"])
+        model = FakeLLMModel().response_always(["reasoning", "content"])
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
 
         assert reasoning == "reasoning"
         assert content == "content"
 
-    def test_get_response_with_callable_string_response(self, fake_model, sample_messages):
+    def test_get_response_with_callable_string_response(self, sample_messages):
         """Test _get_response with callable returning string."""
 
         def response_func(messages, **params):
             return "callable response"
 
-        fake_model.response_always(response_func)
+        model = FakeLLMModel().response_always(response_func)
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
 
         assert reasoning == ""
         assert content == "callable response"
 
-    def test_get_response_with_callable_tuple_response(self, fake_model, sample_messages):
+    def test_get_response_with_callable_tuple_response(self, sample_messages):
         """Test _get_response with callable returning tuple."""
 
         def response_func(messages, **params):
             return ("callable reasoning", "callable content")
 
-        fake_model.response_always(response_func)
+        model = FakeLLMModel().response_always(response_func)
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
+
+        assert reasoning == "callable reasoning"
+        assert content == "callable content"
+
+    def test_get_response_with_callable_list_response(self, sample_messages):
+        """Test _get_response with callable returning list."""
+
+        def response_func(messages, **params):
+            return ["callable reasoning", "callable content"]
+
+        model = FakeLLMModel().response_always(response_func)
+
+        reasoning, content = model._get_response(sample_messages)
 
         assert reasoning == "callable reasoning"
         assert content == "callable content"
@@ -170,240 +244,332 @@ class TestFakeLLMModel:
         with pytest.raises(AssertionError, match="No response rule found for this message."):
             model._get_response(sample_messages)
 
-    def test_get_response_first_matching_rule(self, fake_model, sample_messages):
+    def test_get_response_first_matching_rule(self, sample_messages):
         """Test _get_response returns first matching rule."""
-        fake_model.response_always("first response")
-        fake_model.response_always("second response")
+        model = FakeLLMModel().response_always("first response").response_always("second response")
 
-        reasoning, content = fake_model._get_response(sample_messages)
+        reasoning, content = model._get_response(sample_messages)
 
         assert content == "first response"
 
-    def test_response_always_returns_self(self, fake_model):
-        """Test response_always returns self for chaining."""
-        result = fake_model.response_always("test")
-        assert result is fake_model
+    def test_get_response_passes_params(self, sample_messages):
+        """Test _get_response passes params to callable response."""
 
-    def test_response_always_adds_rule(self, fake_model):
+        def response_func(messages, **params):
+            return f"param: {params.get('test_param')}"
+
+        model = FakeLLMModel().response_always(response_func)
+        reasoning, content = model._get_response(sample_messages, test_param="test_value")
+
+        assert content == "param: test_value"
+
+    def test_with_stream_wps_returns_new_instance(self):
+        """Test with_stream_wps returns new instance."""
+        model = FakeLLMModel(stream_wps=100)
+        new_model = model.with_stream_wps(200)
+
+        assert new_model is not model
+        assert new_model.stream_fps == 200
+        assert model.stream_fps == 100
+
+    def test_with_stream_wps_preserves_rules(self):
+        """Test with_stream_wps preserves existing rules."""
+        model = FakeLLMModel(stream_wps=100).response_always("test")
+        new_model = model.with_stream_wps(200)
+
+        assert new_model.rules_count == 1
+        assert model.rules_count == 1
+
+    def test_response_always_returns_new_instance(self):
+        """Test response_always returns new instance."""
+        model = FakeLLMModel()
+        new_model = model.response_always("test response")
+
+        assert new_model is not model
+        assert new_model.rules_count == 1
+        assert model.rules_count == 0
+
+    def test_response_always_adds_rule(self):
         """Test response_always adds rule to _rules."""
-        fake_model.response_always("test response")
+        model = FakeLLMModel().response_always("test response")
 
-        assert len(fake_model._rules) == 1
-        rule_func, response = fake_model._rules[0]
+        assert len(model._rules) == 1
+        rule_func, response = model._rules[0]
         assert rule_func is _fn_always_true
         assert response == "test response"
 
-    def test_response_when_returns_self(self, fake_model):
-        """Test response_when returns self for chaining."""
+    def test_response_when_returns_new_instance(self):
+        """Test response_when returns new instance."""
 
         def condition(messages, **params):
             return True
 
-        result = fake_model.response_when(condition, "test")
-        assert result is fake_model
+        model = FakeLLMModel()
+        new_model = model.response_when(condition, "test")
 
-    def test_response_when_adds_rule(self, fake_model):
+        assert new_model is not model
+        assert new_model.rules_count == 1
+        assert model.rules_count == 0
+
+    def test_response_when_adds_rule(self):
         """Test response_when adds rule to _rules."""
 
         def condition(messages, **params):
             return len(messages) > 1
 
-        fake_model.response_when(condition, "conditional response")
+        model = FakeLLMModel().response_when(condition, "conditional response")
 
-        assert len(fake_model._rules) == 1
-        rule_func, response = fake_model._rules[0]
+        assert len(model._rules) == 1
+        rule_func, response = model._rules[0]
         assert rule_func is condition
         assert response == "conditional response"
 
-    def test_response_when_keyword_in_last_message_string_keyword(self, fake_model):
+    def test_response_when_keyword_in_last_message_string_keyword(self):
         """Test response_when_keyword_in_last_message with string keyword."""
-        result = fake_model.response_when_keyword_in_last_message("weather", "weather response")
+        model = FakeLLMModel()
+        new_model = model.response_when_keyword_in_last_message("weather", "weather response")
 
-        assert result is fake_model
-        assert len(fake_model._rules) == 1
+        assert new_model is not model
+        assert new_model.rules_count == 1
+        assert model.rules_count == 0
 
-    def test_response_when_keyword_in_last_message_list_keywords(self, fake_model, weather_keywords):
+    def test_response_when_keyword_in_last_message_list_keywords(self, weather_keywords):
         """Test response_when_keyword_in_last_message with list of keywords."""
-        fake_model.response_when_keyword_in_last_message(weather_keywords, "weather response")
+        model = FakeLLMModel().response_when_keyword_in_last_message(weather_keywords, "weather response")
 
-        assert len(fake_model._rules) == 1
+        assert len(model._rules) == 1
 
-    def test_response_when_keyword_in_last_message_tuple_keywords(self, fake_model):
+    def test_response_when_keyword_in_last_message_tuple_keywords(self):
         """Test response_when_keyword_in_last_message with tuple of keywords."""
         keywords = ("weather", "temperature")
-        fake_model.response_when_keyword_in_last_message(keywords, "weather response")
+        model = FakeLLMModel().response_when_keyword_in_last_message(keywords, "weather response")
 
-        assert len(fake_model._rules) == 1
+        assert len(model._rules) == 1
 
-    def test_keyword_check_function_match(self, fake_model):
+    def test_keyword_check_function_match(self):
         """Test keyword check function matches keyword in last message."""
-        fake_model.response_when_keyword_in_last_message("weather", "weather response")
-        rule_func, _ = fake_model._rules[0]
+        model = FakeLLMModel().response_when_keyword_in_last_message("weather", "weather response")
+        rule_func, _ = model._rules[0]
 
         messages = [{"role": "user", "content": "What's the weather like?"}]
         result = rule_func(messages)
 
         assert result is True
 
-    def test_keyword_check_function_no_match(self, fake_model):
+    def test_keyword_check_function_no_match(self):
         """Test keyword check function doesn't match when keyword absent."""
-        fake_model.response_when_keyword_in_last_message("weather", "weather response")
-        rule_func, _ = fake_model._rules[0]
+        model = FakeLLMModel().response_when_keyword_in_last_message("weather", "weather response")
+        rule_func, _ = model._rules[0]
 
         messages = [{"role": "user", "content": "Hello there!"}]
         result = rule_func(messages)
 
         assert result is False
 
-    def test_keyword_check_function_multiple_keywords_match(self, fake_model, weather_keywords):
+    def test_keyword_check_function_multiple_keywords_match(self, weather_keywords):
         """Test keyword check function with multiple keywords, one matches."""
-        fake_model.response_when_keyword_in_last_message(weather_keywords, "weather response")
-        rule_func, _ = fake_model._rules[0]
+        model = FakeLLMModel().response_when_keyword_in_last_message(weather_keywords, "weather response")
+        rule_func, _ = model._rules[0]
 
         messages = [{"role": "user", "content": "Is it sunny today?"}]
         result = rule_func(messages)
 
         assert result is True
 
-    def test_keyword_check_function_multiple_keywords_no_match(self, fake_model, weather_keywords):
+    def test_keyword_check_function_multiple_keywords_no_match(self, weather_keywords):
         """Test keyword check function with multiple keywords, none match."""
-        fake_model.response_when_keyword_in_last_message(weather_keywords, "weather response")
-        rule_func, _ = fake_model._rules[0]
+        model = FakeLLMModel().response_when_keyword_in_last_message(weather_keywords, "weather response")
+        rule_func, _ = model._rules[0]
 
         messages = [{"role": "user", "content": "Hello world!"}]
         result = rule_func(messages)
 
         assert result is False
 
-    def test_ask_without_reasoning(self, fake_model, sample_messages):
-        """Test ask method without reasoning."""
-        fake_model.response_always("test response")
+    def test_keyword_check_function_ignores_params(self):
+        """Test keyword check function ignores additional params."""
+        model = FakeLLMModel().response_when_keyword_in_last_message("test", "response")
+        rule_func, _ = model._rules[0]
 
-        result = fake_model.ask(sample_messages)
+        messages = [{"role": "user", "content": "test message"}]
+        result = rule_func(messages, extra_param="value")
+
+        assert result is True
+
+    def test_clear_rules_returns_new_instance(self):
+        """Test clear_rules returns new instance."""
+        model = FakeLLMModel().response_always("test")
+        new_model = model.clear_rules()
+
+        assert new_model is not model
+        assert new_model.rules_count == 0
+        assert model.rules_count == 1
+
+    def test_clear_rules_removes_all_rules(self):
+        """Test clear_rules removes all rules."""
+        model = (FakeLLMModel()
+                 .response_always("test1")
+                 .response_always("test2")
+                 .response_always("test3"))
+
+        clean_model = model.clear_rules()
+
+        assert clean_model.rules_count == 0
+
+    def test_ask_without_reasoning(self, sample_messages):
+        """Test ask method without reasoning."""
+        model = FakeLLMModel().response_always("test response")
+
+        result = model.ask(sample_messages)
 
         assert result == "test response"
 
-    def test_ask_with_reasoning(self, fake_model, sample_messages):
+    def test_ask_with_reasoning(self, sample_messages):
         """Test ask method with reasoning."""
-        fake_model.response_always(("reasoning", "content"))
+        model = FakeLLMModel().response_always(("reasoning", "content"))
 
-        result = fake_model.ask(sample_messages, with_reasoning=True)
+        result = model.ask(sample_messages, with_reasoning=True)
 
         assert result == ("reasoning", "content")
 
-    def test_ask_with_params(self, fake_model, sample_messages):
+    def test_ask_with_params(self, sample_messages):
         """Test ask method passes params to _get_response."""
 
         def response_func(messages, **params):
             return f"param value: {params.get('test_param')}"
 
-        fake_model.response_always(response_func)
+        model = FakeLLMModel().response_always(response_func)
 
-        result = fake_model.ask(sample_messages, test_param="test_value")
+        result = model.ask(sample_messages, test_param="test_value")
 
         assert result == "param value: test_value"
 
-    def test_iter_per_words_content_only(self, fake_model, mock_jieba_cut):
+    def test_iter_per_words_content_only(self, mock_jieba_cut):
         """Test _iter_per_words with content only."""
+        model = FakeLLMModel(stream_wps=100)
         mock_jieba_cut.return_value = ["Hello", "world"]
 
         with patch('time.sleep') as mock_sleep:
-            chunks = list(fake_model._iter_per_words("Hello world"))
+            chunks = list(model._iter_per_words("Hello world"))
 
         expected_chunks = [(None, "Hello"), (None, "world")]
         assert chunks == expected_chunks
         assert mock_sleep.call_count == 2
         mock_sleep.assert_called_with(1 / 100)  # stream_fps = 100
 
-    def test_iter_per_words_reasoning_and_content(self, fake_model, mock_jieba_cut):
+    def test_iter_per_words_reasoning_and_content(self, mock_jieba_cut):
         """Test _iter_per_words with both reasoning and content."""
+        model = FakeLLMModel(stream_wps=100)
         mock_jieba_cut.side_effect = [["Think", "about"], ["Hello", "world"]]
 
         with patch('time.sleep') as mock_sleep:
-            chunks = list(fake_model._iter_per_words("Hello world", "Think about"))
+            chunks = list(model._iter_per_words("Hello world", "Think about"))
 
         expected_chunks = [("Think", None), ("about", None), (None, "Hello"), (None, "world")]
         assert chunks == expected_chunks
         assert mock_sleep.call_count == 4
 
-    def test_iter_per_words_empty_words_filtered(self, fake_model, mock_jieba_cut):
+    def test_iter_per_words_empty_words_filtered(self, mock_jieba_cut):
         """Test _iter_per_words filters out empty words."""
+        model = FakeLLMModel(stream_wps=100)
         mock_jieba_cut.return_value = ["Hello", "", "world", ""]
 
         with patch('time.sleep'):
-            chunks = list(fake_model._iter_per_words("Hello world"))
+            chunks = list(model._iter_per_words("Hello world"))
 
         expected_chunks = [(None, "Hello"), (None, "world")]
         assert chunks == expected_chunks
 
-    def test_iter_per_words_empty_content(self, fake_model, mock_jieba_cut):
+    def test_iter_per_words_empty_content(self, mock_jieba_cut):
         """Test _iter_per_words with empty content."""
-        chunks = list(fake_model._iter_per_words(""))
+        model = FakeLLMModel(stream_wps=100)
+        chunks = list(model._iter_per_words(""))
         assert chunks == []
 
-    def test_iter_per_words_empty_reasoning(self, fake_model, mock_jieba_cut):
+    def test_iter_per_words_empty_reasoning(self, mock_jieba_cut):
         """Test _iter_per_words with empty reasoning content."""
+        model = FakeLLMModel(stream_wps=100)
         mock_jieba_cut.return_value = ["Hello"]
 
         with patch('time.sleep'):
-            chunks = list(fake_model._iter_per_words("Hello", ""))
+            chunks = list(model._iter_per_words("Hello", ""))
 
         expected_chunks = [(None, "Hello")]
         assert chunks == expected_chunks
 
-    def test_ask_stream_returns_fake_response_stream(self, fake_model, sample_messages):
-        """Test ask_stream returns FakeResponseStream."""
-        fake_model.response_always("test response")
+    def test_iter_per_words_none_reasoning(self, mock_jieba_cut):
+        """Test _iter_per_words with None reasoning content."""
+        model = FakeLLMModel(stream_wps=100)
+        mock_jieba_cut.return_value = ["Hello"]
 
-        stream = fake_model.ask_stream(sample_messages)
+        with patch('time.sleep'):
+            chunks = list(model._iter_per_words("Hello", None))
+
+        expected_chunks = [(None, "Hello")]
+        assert chunks == expected_chunks
+
+    def test_iter_per_words_none_content(self, mock_jieba_cut):
+        """Test _iter_per_words with None content."""
+        model = FakeLLMModel(stream_wps=100)
+        mock_jieba_cut.return_value = ["Think"]
+
+        with patch('time.sleep'):
+            chunks = list(model._iter_per_words(None, "Think"))
+
+        expected_chunks = [("Think", None)]
+        assert chunks == expected_chunks
+
+    def test_iter_per_words_stream_fps_timing(self, mock_jieba_cut):
+        """Test _iter_per_words uses correct timing based on stream_fps."""
+        model = FakeLLMModel(stream_wps=50)
+        mock_jieba_cut.return_value = ["Hello"]
+
+        with patch('time.sleep') as mock_sleep:
+            list(model._iter_per_words("Hello"))
+
+        mock_sleep.assert_called_with(1 / 50)
+
+    def test_ask_stream_returns_fake_response_stream(self, sample_messages):
+        """Test ask_stream returns FakeResponseStream."""
+        model = FakeLLMModel().response_always("test response")
+
+        stream = model.ask_stream(sample_messages)
 
         assert isinstance(stream, FakeResponseStream)
 
-    def test_ask_stream_with_reasoning_true(self, fake_model, sample_messages):
+    def test_ask_stream_with_reasoning_true(self, sample_messages):
         """Test ask_stream with with_reasoning=True."""
-        fake_model.response_always(("reasoning", "content"))
+        model = FakeLLMModel().response_always(("reasoning", "content"))
 
-        stream = fake_model.ask_stream(sample_messages, with_reasoning=True)
+        stream = model.ask_stream(sample_messages, with_reasoning=True)
 
         assert stream._with_reasoning is True
 
-    def test_ask_stream_with_reasoning_false(self, fake_model, sample_messages):
+    def test_ask_stream_with_reasoning_false(self, sample_messages):
         """Test ask_stream with with_reasoning=False."""
-        fake_model.response_always("content")
+        model = FakeLLMModel().response_always("content")
 
-        stream = fake_model.ask_stream(sample_messages, with_reasoning=False)
+        stream = model.ask_stream(sample_messages, with_reasoning=False)
 
         assert stream._with_reasoning is False
 
-    def test_ask_stream_passes_params(self, fake_model, sample_messages):
-        """Test ask_stream passes params to _get_response."""
-
-        def response_func(messages, **params):
-            return f"param: {params.get('test_param')}"
-
-        fake_model.response_always(response_func)
-
-        with patch.object(fake_model, '_get_response', wraps=fake_model._get_response) as mock_get_response:
-            fake_model.ask_stream(sample_messages, test_param="test_value")
-            mock_get_response.assert_called_once_with(messages=sample_messages, test_param="test_value")
-
-    def test_method_chaining(self, fake_model):
+    def test_method_chaining(self):
         """Test method chaining works correctly."""
-        result = (fake_model
+        result = (FakeLLMModel()
                   .response_when_keyword_in_last_message("hello", "hi response")
                   .response_when_keyword_in_last_message("weather", "weather response")
                   .response_always("default response"))
 
-        assert result is fake_model
-        assert len(fake_model._rules) == 3
+        assert result.rules_count == 3
 
-    def test_rule_priority_order(self, fake_model):
+    def test_rule_priority_order(self):
         """Test that rules are checked in the order they were added."""
-        fake_model.response_when_keyword_in_last_message("test", "first match")
-        fake_model.response_always("second match")
+        model = (FakeLLMModel()
+                 .response_when_keyword_in_last_message("test", "first match")
+                 .response_always("second match"))
 
         messages = [{"role": "user", "content": "this is a test message"}]
-        result = fake_model.ask(messages)
+        result = model.ask(messages)
 
         assert result == "first match"
 
@@ -419,9 +585,191 @@ class TestFakeLLMModel:
         result = repr(model)
         assert result == "FakeLLMModel(stream_fps=100, rules_count=0)"
 
-    def test_repr_with_rules(self, fake_model):
+    def test_repr_with_rules(self):
         """Test __repr__ with rules added."""
-        fake_model.response_always("response1")
-        fake_model.response_always("response2")
-        result = repr(fake_model)
+        model = FakeLLMModel(stream_wps=100).response_always("response1").response_always("response2")
+        result = repr(model)
         assert result == "FakeLLMModel(stream_fps=100, rules_count=2)"
+
+    def test_params_method_basic(self):
+        """Test _params method returns correct parameters."""
+        model = FakeLLMModel(stream_wps=100)
+        params = model._params()
+
+        assert isinstance(params, tuple)
+        assert params[0] == 100  # stream_fps
+        assert params[1] == tuple()  # empty rules
+
+    def test_params_method_with_rules(self):
+        """Test _params method with rules."""
+
+        def custom_rule(messages, **params):
+            return True
+
+        model = FakeLLMModel(stream_wps=100).response_when(custom_rule, "response")
+        params = model._params()
+
+        assert params[0] == 100
+        assert len(params[1]) == 1  # one rule
+
+        rule_key, response_key = params[1][0]
+        assert rule_key[0] == id(custom_rule)  # function id
+        assert rule_key[1] == str(custom_rule)  # function string
+        assert response_key == ('value', 'response')
+
+    def test_params_method_with_callable_response(self):
+        """Test _params method with callable response."""
+
+        def response_func(messages, **params):
+            return "response"
+
+        model = FakeLLMModel().response_always(response_func)
+        params = model._params()
+
+        rule_key, response_key = params[1][0]
+        assert response_key[0] == 'callable'
+        assert response_key[1] == id(response_func)
+        assert response_key[2] == str(response_func)
+
+    def test_params_method_with_tuple_response(self):
+        """Test _params method with tuple response."""
+        model = FakeLLMModel().response_always(("reasoning", "content"))
+        params = model._params()
+
+        rule_key, response_key = params[1][0]
+        assert response_key == ('tuple', ('reasoning', 'content'))
+
+    def test_params_method_with_list_response(self):
+        """Test _params method with list response."""
+        model = FakeLLMModel().response_always(["reasoning", "content"])
+        params = model._params()
+
+        rule_key, response_key = params[1][0]
+        assert response_key == ('tuple', ('reasoning', 'content'))
+
+    def test_params_method_multiple_rules(self):
+        """Test _params method with multiple rules."""
+
+        def rule1(messages, **params):
+            return True
+
+        def rule2(messages, **params):
+            return False
+
+        model = (FakeLLMModel(stream_wps=50)
+                 .response_when(rule1, "response1")
+                 .response_when(rule2, ("reasoning", "response2")))
+        params = model._params()
+
+        assert params[0] == 50
+        assert len(params[1]) == 2
+
+    def test_equality_same_instance(self):
+        """Test equality with same instance."""
+        model = FakeLLMModel(stream_wps=100)
+        assert model == model
+
+    def test_equality_different_instances_same_params(self):
+        """Test equality with different instances but same parameters."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=100)
+        assert model1 == model2
+
+    def test_equality_different_stream_wps(self):
+        """Test inequality with different stream_wps."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=200)
+        assert model1 != model2
+
+    def test_equality_different_rules(self):
+        """Test inequality with different rules."""
+        model1 = FakeLLMModel().response_always("response1")
+        model2 = FakeLLMModel().response_always("response2")
+        assert model1 != model2
+
+    def test_equality_same_rules_different_order(self):
+        """Test inequality with same rules in different order."""
+        model1 = (FakeLLMModel()
+                  .response_always("response1")
+                  .response_always("response2"))
+        model2 = (FakeLLMModel()
+                  .response_always("response2")
+                  .response_always("response1"))
+        assert model1 != model2
+
+    def test_equality_with_non_llm_model(self):
+        """Test inequality with non-LLMModel object."""
+        model = FakeLLMModel()
+        assert model != "not a model"
+        assert model != 42
+        assert model != None
+
+    def test_equality_with_different_llm_model_type(self):
+        """Test inequality with different LLMModel subclass."""
+        from hbllmutils.model.base import LLMModel
+
+        class OtherLLMModel(LLMModel):
+            @property
+            def _logger_name(self):
+                return "other"
+
+            def ask(self, messages, with_reasoning=False, **params):
+                return "response"
+
+            def ask_stream(self, messages, with_reasoning=False, **params):
+                pass
+
+            def _params(self):
+                return (100,)
+
+        fake_model = FakeLLMModel(stream_wps=100)
+        other_model = OtherLLMModel()
+        assert fake_model != other_model
+
+    def test_hash_same_instances(self):
+        """Test hash is same for instances with same parameters."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=100)
+        assert hash(model1) == hash(model2)
+
+    def test_hash_different_instances(self):
+        """Test hash is different for instances with different parameters."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=200)
+        assert hash(model1) != hash(model2)
+
+    def test_hash_with_rules(self):
+        """Test hash with rules."""
+        model1 = FakeLLMModel().response_always("response")
+        model2 = FakeLLMModel().response_always("response")
+        # Note: These may not be equal due to different function objects
+        # but they should be hashable
+        assert isinstance(hash(model1), int)
+        assert isinstance(hash(model2), int)
+
+    def test_hash_consistency(self):
+        """Test hash consistency - same object should have same hash."""
+        model = FakeLLMModel(stream_wps=100).response_always("test")
+        hash1 = hash(model)
+        hash2 = hash(model)
+        assert hash1 == hash2
+
+    def test_hashable_in_set(self):
+        """Test that FakeLLMModel instances can be used in sets."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=200)
+        model3 = FakeLLMModel(stream_wps=100)
+
+        model_set = {model1, model2, model3}
+        # model1 and model3 should be considered equal, so set should have 2 elements
+        assert len(model_set) == 2
+
+    def test_hashable_in_dict(self):
+        """Test that FakeLLMModel instances can be used as dict keys."""
+        model1 = FakeLLMModel(stream_wps=100)
+        model2 = FakeLLMModel(stream_wps=200)
+
+        model_dict = {model1: "value1", model2: "value2"}
+        assert len(model_dict) == 2
+        assert model_dict[model1] == "value1"
+        assert model_dict[model2] == "value2"

--- a/test/model/test_fake.py
+++ b/test/model/test_fake.py
@@ -89,13 +89,13 @@ class TestFakeLLMModel:
     def test_init_default_stream_wps(self):
         """Test FakeLLMModel initialization with default stream_wps."""
         model = FakeLLMModel()
-        assert model.stream_fps == 50
+        assert model.stream_wps == 50
         assert model.rules_count == 0
 
     def test_init_custom_stream_wps(self):
         """Test FakeLLMModel initialization with custom stream_wps."""
         model = FakeLLMModel(stream_wps=100)
-        assert model.stream_fps == 100
+        assert model.stream_wps == 100
         assert model.rules_count == 0
 
     def test_init_with_rules(self):
@@ -114,8 +114,8 @@ class TestFakeLLMModel:
     def test_immutability_setattr_after_frozen(self):
         """Test that attributes cannot be modified after initialization."""
         model = FakeLLMModel()
-        with pytest.raises(AttributeError, match="Cannot modify attribute '_stream_fps' of immutable FakeLLMModel"):
-            model._stream_fps = 200
+        with pytest.raises(AttributeError, match="Cannot modify attribute '_stream_wps' of immutable FakeLLMModel"):
+            model._stream_wps = 200
 
     def test_immutability_setattr_new_attribute(self):
         """Test that new attributes cannot be added after initialization."""
@@ -126,8 +126,8 @@ class TestFakeLLMModel:
     def test_immutability_delattr(self):
         """Test that attributes cannot be deleted."""
         model = FakeLLMModel()
-        with pytest.raises(AttributeError, match="Cannot delete attribute '_stream_fps' of immutable FakeLLMModel"):
-            del model._stream_fps
+        with pytest.raises(AttributeError, match="Cannot delete attribute '_stream_wps' of immutable FakeLLMModel"):
+            del model._stream_wps
 
     def test_logger_name_property(self):
         """Test _logger_name property."""
@@ -153,7 +153,7 @@ class TestFakeLLMModel:
         new_model = model._create_new_instance()
 
         assert new_model is not model
-        assert new_model.stream_fps == 100
+        assert new_model.stream_wps == 100
         assert new_model.rules_count == 0
 
     def test_create_new_instance_override_stream_wps(self):
@@ -161,7 +161,7 @@ class TestFakeLLMModel:
         model = FakeLLMModel(stream_wps=100)
         new_model = model._create_new_instance(stream_wps=200)
 
-        assert new_model.stream_fps == 200
+        assert new_model.stream_wps == 200
 
     def test_create_new_instance_override_rules(self):
         """Test _create_new_instance with overridden rules."""
@@ -269,8 +269,8 @@ class TestFakeLLMModel:
         new_model = model.with_stream_wps(200)
 
         assert new_model is not model
-        assert new_model.stream_fps == 200
-        assert model.stream_fps == 100
+        assert new_model.stream_wps == 200
+        assert model.stream_wps == 100
 
     def test_with_stream_wps_preserves_rules(self):
         """Test with_stream_wps preserves existing rules."""
@@ -455,7 +455,7 @@ class TestFakeLLMModel:
         expected_chunks = [(None, "Hello"), (None, "world")]
         assert chunks == expected_chunks
         assert mock_sleep.call_count == 2
-        mock_sleep.assert_called_with(1 / 100)  # stream_fps = 100
+        mock_sleep.assert_called_with(1 / 100)  # stream_wps = 100
 
     def test_iter_per_words_reasoning_and_content(self, mock_jieba_cut):
         """Test _iter_per_words with both reasoning and content."""
@@ -519,8 +519,8 @@ class TestFakeLLMModel:
         expected_chunks = [("Think", None)]
         assert chunks == expected_chunks
 
-    def test_iter_per_words_stream_fps_timing(self, mock_jieba_cut):
-        """Test _iter_per_words uses correct timing based on stream_fps."""
+    def test_iter_per_words_stream_wps_timing(self, mock_jieba_cut):
+        """Test _iter_per_words uses correct timing based on stream_wps."""
         model = FakeLLMModel(stream_wps=50)
         mock_jieba_cut.return_value = ["Hello"]
 
@@ -577,19 +577,19 @@ class TestFakeLLMModel:
         """Test __repr__ with default stream_wps."""
         model = FakeLLMModel()
         result = repr(model)
-        assert result == "FakeLLMModel(stream_fps=50, rules_count=0)"
+        assert result == "FakeLLMModel(stream_wps=50, rules_count=0)"
 
     def test_repr_custom_stream_wps(self):
         """Test __repr__ with custom stream_wps."""
         model = FakeLLMModel(stream_wps=100)
         result = repr(model)
-        assert result == "FakeLLMModel(stream_fps=100, rules_count=0)"
+        assert result == "FakeLLMModel(stream_wps=100, rules_count=0)"
 
     def test_repr_with_rules(self):
         """Test __repr__ with rules added."""
         model = FakeLLMModel(stream_wps=100).response_always("response1").response_always("response2")
         result = repr(model)
-        assert result == "FakeLLMModel(stream_fps=100, rules_count=2)"
+        assert result == "FakeLLMModel(stream_wps=100, rules_count=2)"
 
     def test_params_method_basic(self):
         """Test _params method returns correct parameters."""
@@ -597,7 +597,7 @@ class TestFakeLLMModel:
         params = model._params()
 
         assert isinstance(params, tuple)
-        assert params[0] == 100  # stream_fps
+        assert params[0] == 100  # stream_wps
         assert params[1] == tuple()  # empty rules
 
     def test_params_method_with_rules(self):

--- a/test/model/test_fake.py
+++ b/test/model/test_fake.py
@@ -297,14 +297,14 @@ class TestFakeResponseSequence:
         """Test __repr__ method."""
         sequence = FakeResponseSequence(sample_responses, index=1)
         result = repr(sequence)
-        expected = f"_ResponseSequence(responses={list(sample_responses)}, index=1)"
+        expected = f"FakeResponseSequence(responses={list(sample_responses)}, index=1)"
         assert result == expected
 
     def test_repr_empty_responses(self, empty_responses):
         """Test __repr__ method with empty responses."""
         sequence = FakeResponseSequence(empty_responses)
         result = repr(sequence)
-        expected = "_ResponseSequence(responses=[], index=0)"
+        expected = "FakeResponseSequence(responses=[], index=0)"
         assert result == expected
 
 

--- a/test/model/test_task.py
+++ b/test/model/test_task.py
@@ -1,0 +1,340 @@
+import logging
+
+import pytest
+
+from hbllmutils.history import LLMHistory
+from hbllmutils.model import FakeLLMModel, LLMTask, ResponseStream
+
+
+@pytest.fixture
+def mock_model():
+    """Create a mock FakeLLMModel for testing."""
+    return FakeLLMModel().response_always("Test response")
+
+
+@pytest.fixture
+def mock_model_with_reasoning():
+    """Create a mock FakeLLMModel that returns reasoning and response."""
+    return FakeLLMModel().response_always(("Test reasoning", "Test response"))
+
+
+@pytest.fixture
+def empty_history():
+    """Create an empty LLMHistory for testing."""
+    return LLMHistory()
+
+
+@pytest.fixture
+def history_with_messages():
+    """Create an LLMHistory with some messages for testing."""
+    history = LLMHistory()
+    history = history.with_user_message("Hello")
+    history = history.with_assistant_message("Hi there")
+    return history
+
+
+@pytest.fixture
+def mock_stream_model():
+    """Create a mock FakeLLMModel for stream testing."""
+    return FakeLLMModel(stream_wps=100).response_always("Stream response")
+
+
+@pytest.mark.unittest
+class TestLLMTask:
+
+    def test_init_with_model_only(self, mock_model):
+        """Test initialization with model only."""
+
+        task = LLMTask(mock_model)
+        assert task.model is mock_model
+        assert isinstance(task.history, LLMHistory)
+        assert len(task.history) == 0
+
+    def test_init_with_model_and_history(self, mock_model, history_with_messages):
+        """Test initialization with model and history."""
+
+        task = LLMTask(mock_model, history_with_messages)
+        assert task.model is mock_model
+        assert task.history is history_with_messages
+        assert len(task.history) == 2
+
+    def test_logger_property(self, mock_model):
+        """Test _logger property returns model's logger."""
+
+        task = LLMTask(mock_model)
+        logger = task._logger
+        assert isinstance(logger, logging.Logger)
+        assert logger is mock_model._logger
+
+    def test_ask_without_reasoning(self, mock_model, history_with_messages):
+        """Test ask method without reasoning."""
+
+        task = LLMTask(mock_model, history_with_messages)
+        response = task.ask()
+
+        assert response == "Test response"
+        assert isinstance(response, str)
+
+    def test_ask_with_reasoning_false(self, mock_model_with_reasoning, history_with_messages):
+        """Test ask method with reasoning=False."""
+
+        task = LLMTask(mock_model_with_reasoning, history_with_messages)
+        response = task.ask(with_reasoning=False)
+
+        assert response == "Test response"
+        assert isinstance(response, str)
+
+    def test_ask_with_reasoning_true(self, mock_model_with_reasoning, history_with_messages):
+        """Test ask method with reasoning=True."""
+
+        task = LLMTask(mock_model_with_reasoning, history_with_messages)
+        response = task.ask(with_reasoning=True)
+
+        assert isinstance(response, tuple)
+        assert len(response) == 2
+        assert response[0] == "Test reasoning"
+        assert response[1] == "Test response"
+
+    def test_ask_with_params(self, mock_model, history_with_messages):
+        """Test ask method with additional parameters."""
+
+        # Create a model that can handle parameters
+        def response_func(messages, **params):
+            if params.get('temperature') == 0.5:
+                return "Custom response"
+            return "Default response"
+
+        custom_model = FakeLLMModel().response_always(response_func)
+        task = LLMTask(custom_model, history_with_messages)
+
+        response = task.ask(temperature=0.5)
+        assert response == "Custom response"
+
+    def test_ask_stream_without_reasoning(self, mock_stream_model, history_with_messages):
+        """Test ask_stream method without reasoning."""
+
+        task = LLMTask(mock_stream_model, history_with_messages)
+        stream = task.ask_stream()
+
+        assert isinstance(stream, ResponseStream)
+        # Collect all chunks
+        chunks = list(stream)
+        full_response = ''.join(chunks)
+        assert "Stream response" in full_response
+
+    def test_ask_stream_with_reasoning_false(self, mock_stream_model, history_with_messages):
+        """Test ask_stream method with reasoning=False."""
+
+        task = LLMTask(mock_stream_model, history_with_messages)
+        stream = task.ask_stream(with_reasoning=False)
+
+        assert isinstance(stream, ResponseStream)
+        chunks = list(stream)
+        full_response = ''.join(chunks)
+        assert "Stream response" in full_response
+
+    def test_ask_stream_with_reasoning_true(self, mock_stream_model, history_with_messages):
+        """Test ask_stream method with reasoning=True."""
+
+        # Create model with reasoning
+        reasoning_model = FakeLLMModel(stream_wps=100).response_always(("Stream reasoning", "Stream response"))
+        task = LLMTask(reasoning_model, history_with_messages)
+
+        stream = task.ask_stream(with_reasoning=True)
+        assert isinstance(stream, ResponseStream)
+
+        # Check that we can iterate through the stream
+        chunks = list(stream)
+        assert len(chunks) > 0
+
+    def test_ask_stream_with_params(self, mock_stream_model, history_with_messages):
+        """Test ask_stream method with additional parameters."""
+
+        # Create a model that can handle parameters
+        def response_func(messages, **params):
+            if params.get('max_tokens') == 100:
+                return "Limited response"
+            return "Full response"
+
+        custom_model = FakeLLMModel(stream_wps=100).response_always(response_func)
+        task = LLMTask(custom_model, history_with_messages)
+
+        stream = task.ask_stream(max_tokens=100)
+        chunks = list(stream)
+        full_response = ''.join(chunks)
+        assert "Limited response" in full_response
+
+    def test_params_method(self, mock_model, history_with_messages):
+        """Test _params method returns model and history."""
+
+        task = LLMTask(mock_model, history_with_messages)
+        params = task._params()
+
+        assert isinstance(params, tuple)
+        assert len(params) == 2
+        assert params[0] is mock_model
+        assert params[1] is history_with_messages
+
+    def test_values_method(self, mock_model, history_with_messages):
+        """Test _values method returns class and params."""
+
+        task = LLMTask(mock_model, history_with_messages)
+        values = task._values()
+
+        assert isinstance(values, tuple)
+        assert len(values) == 2
+        assert values[0] is LLMTask
+        assert values[1] == task._params()
+
+    def test_equality_same_instances(self, mock_model, history_with_messages):
+        """Test equality with same model and history instances."""
+
+        task1 = LLMTask(mock_model, history_with_messages)
+        task2 = LLMTask(mock_model, history_with_messages)
+
+        assert task1 == task2
+
+    def test_equality_different_models(self, mock_model, history_with_messages):
+        """Test equality with different models."""
+
+        different_model = FakeLLMModel().response_always("Different response")
+        task1 = LLMTask(mock_model, history_with_messages)
+        task2 = LLMTask(different_model, history_with_messages)
+
+        assert task1 != task2
+
+    def test_equality_different_histories(self, mock_model, history_with_messages, empty_history):
+        """Test equality with different histories."""
+
+        task1 = LLMTask(mock_model, history_with_messages)
+        task2 = LLMTask(mock_model, empty_history)
+
+        assert task1 != task2
+
+    def test_equality_different_types(self, mock_model, history_with_messages):
+        """Test equality with different object types."""
+
+        task = LLMTask(mock_model, history_with_messages)
+
+        assert task != "not a task"
+        assert task != 123
+        assert task != None
+        assert task != mock_model
+
+    def test_equality_same_values_different_instances(self, history_with_messages):
+        """Test equality with equivalent but different instances."""
+
+        model1 = FakeLLMModel().response_always("Same response")
+        model2 = FakeLLMModel().response_always("Same response")
+
+        # Create equivalent histories
+        history1 = LLMHistory().with_user_message("Hello").with_assistant_message("Hi there")
+        history2 = LLMHistory().with_user_message("Hello").with_assistant_message("Hi there")
+
+        task1 = LLMTask(model1, history1)
+        task2 = LLMTask(model2, history2)
+
+        # They should be equal if the models and histories are equal
+        assert task1 == task2
+
+    def test_hash_consistency(self, mock_model, history_with_messages):
+        """Test hash consistency."""
+
+        task = LLMTask(mock_model, history_with_messages)
+        hash1 = hash(task)
+        hash2 = hash(task)
+
+        assert hash1 == hash2
+
+    def test_hash_equality_implies_same_hash(self, history_with_messages):
+        """Test that equal objects have the same hash."""
+        model1 = FakeLLMModel().response_always("Same response")
+        model2 = FakeLLMModel().response_always("Same response")
+
+        # Create equivalent histories
+        history1 = LLMHistory().with_user_message("Hello").with_assistant_message("Hi there")
+        history2 = LLMHistory().with_user_message("Hello").with_assistant_message("Hi there")
+
+        task1 = LLMTask(model1, history1)
+        task2 = LLMTask(model2, history2)
+
+        if task1 == task2:
+            assert hash(task1) == hash(task2)
+
+    def test_hash_different_objects(self, mock_model, history_with_messages, empty_history):
+        """Test that different objects typically have different hashes."""
+
+        task1 = LLMTask(mock_model, history_with_messages)
+        task2 = LLMTask(mock_model, empty_history)
+
+        # Different objects should typically have different hashes
+        # Note: Hash collisions are possible but unlikely
+        assert hash(task1) != hash(task2)
+
+    def test_ask_passes_history_to_model(self, history_with_messages):
+        """Test that ask method passes history.to_json() to model."""
+
+        # Create a model that captures the messages parameter
+        captured_messages = None
+
+        def capture_messages(messages, **params):
+            nonlocal captured_messages
+            captured_messages = messages
+            return "Response"
+
+        model = FakeLLMModel().response_always(capture_messages)
+        task = LLMTask(model, history_with_messages)
+
+        task.ask()
+
+        assert captured_messages is not None
+        assert captured_messages == history_with_messages.to_json()
+
+    def test_ask_stream_passes_history_to_model(self, history_with_messages):
+        """Test that ask_stream method passes history.to_json() to model."""
+
+        # Create a model that captures the messages parameter
+        captured_messages = None
+
+        def capture_messages(messages, **params):
+            nonlocal captured_messages
+            captured_messages = messages
+            return "Stream response"
+
+        model = FakeLLMModel(stream_wps=100).response_always(capture_messages)
+        task = LLMTask(model, history_with_messages)
+
+        stream = task.ask_stream()
+        # Consume the stream to trigger the model call
+        list(stream)
+
+        assert captured_messages is not None
+        assert captured_messages == history_with_messages.to_json()
+
+    def test_empty_history_initialization(self, mock_model):
+        """Test that empty history is created when none provided."""
+
+        task = LLMTask(mock_model)
+
+        assert isinstance(task.history, LLMHistory)
+        assert len(task.history) == 0
+        assert task.history.to_json() == []
+
+    def test_ask_with_empty_history(self, mock_model, empty_history):
+        """Test ask method with empty history."""
+
+        task = LLMTask(mock_model, empty_history)
+        response = task.ask()
+
+        assert response == "Test response"
+
+    def test_ask_stream_with_empty_history(self, mock_stream_model, empty_history):
+        """Test ask_stream method with empty history."""
+
+        task = LLMTask(mock_stream_model, empty_history)
+        stream = task.ask_stream()
+
+        assert isinstance(stream, ResponseStream)
+        chunks = list(stream)
+        full_response = ''.join(chunks)
+        assert "Stream response" in full_response

--- a/test/response/test_parsable.py
+++ b/test/response/test_parsable.py
@@ -1,0 +1,352 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from hbllmutils.history import LLMHistory
+from hbllmutils.model import FakeLLMModel, LLMTask
+from hbllmutils.response import ParsableLLMTask, OutputParseWithException, OutputParseFailed
+
+
+@pytest.fixture
+def fake_model():
+    """Create a basic fake LLM model for testing."""
+    return FakeLLMModel()
+
+
+@pytest.fixture
+def history():
+    """Create an empty LLM history for testing."""
+    return LLMHistory()
+
+
+@pytest.fixture
+def model_with_responses():
+    """Create a fake model with predefined responses."""
+    return FakeLLMModel().response_sequence([
+        "invalid_json",
+        "still_invalid",
+        '{"valid": "json"}'
+    ])
+
+
+@pytest.fixture
+def model_always_invalid():
+    """Create a fake model that always returns invalid responses."""
+    return FakeLLMModel().response_always("invalid_response")
+
+
+@pytest.fixture
+def model_always_valid():
+    """Create a fake model that always returns valid responses."""
+    return FakeLLMModel().response_always('{"valid": "json"}')
+
+
+@pytest.fixture
+def logger_mock():
+    """Create a mock logger for testing."""
+    return Mock(spec=logging.Logger)
+
+
+class TestParsableTask(ParsableLLMTask):
+    """Test implementation of ParsableLLMTask for JSON parsing."""
+
+    def _parse_and_validate(self, content: str):
+        import json
+        return json.loads(content)
+
+
+class TestParsableTaskWithCustomExceptions(ParsableLLMTask):
+    """Test implementation with custom exception types."""
+    __exceptions__ = (ValueError, KeyError)
+
+    def _parse_and_validate(self, content: str):
+        if content == "value_error":
+            raise ValueError("Value error")
+        elif content == "key_error":
+            raise KeyError("Key error")
+        elif content == "type_error":
+            raise TypeError("Type error")
+        else:
+            return content
+
+
+class TestParsableTaskAlwaysFails(ParsableLLMTask):
+    """Test implementation that always fails parsing."""
+
+    def _parse_and_validate(self, content: str):
+        raise ValueError("Always fails")
+
+
+@pytest.mark.unittest
+class TestOutputParseWithException:
+    """Test cases for OutputParseWithException data class."""
+
+    def test_initialization(self):
+        """Test OutputParseWithException initialization."""
+        exception = ValueError("Test error")
+        output = "test output"
+
+        parse_attempt = OutputParseWithException(output=output, exception=exception)
+
+        assert parse_attempt.output == output
+        assert parse_attempt.exception == exception
+
+    def test_attributes_access(self):
+        """Test accessing attributes of OutputParseWithException."""
+        exception = RuntimeError("Runtime error")
+        output = "runtime output"
+
+        parse_attempt = OutputParseWithException(output=output, exception=exception)
+
+        assert parse_attempt.output == "runtime output"
+        assert isinstance(parse_attempt.exception, RuntimeError)
+        assert str(parse_attempt.exception) == "Runtime error"
+
+
+@pytest.mark.unittest
+class TestOutputParseFailed:
+    """Test cases for OutputParseFailed exception."""
+
+    def test_initialization(self):
+        """Test OutputParseFailed initialization."""
+        tries = [
+            OutputParseWithException("output1", ValueError("error1")),
+            OutputParseWithException("output2", ValueError("error2"))
+        ]
+        message = "Parsing failed"
+
+        exception = OutputParseFailed(message, tries)
+
+        assert str(exception) == message
+        assert exception.tries == tries
+
+    def test_empty_tries_list(self):
+        """Test OutputParseFailed with empty tries list."""
+        tries = []
+        message = "No attempts made"
+
+        exception = OutputParseFailed(message, tries)
+
+        assert str(exception) == message
+        assert exception.tries == []
+
+    def test_inheritance(self):
+        """Test that OutputParseFailed inherits from Exception."""
+        tries = [OutputParseWithException("output", ValueError("error"))]
+        exception = OutputParseFailed("test", tries)
+
+        assert isinstance(exception, Exception)
+
+
+@pytest.mark.unittest
+class TestParsableLLMTask:
+    """Test cases for ParsableLLMTask class."""
+
+    def test_initialization_default_params(self, fake_model):
+        """Test ParsableLLMTask initialization with default parameters."""
+        task = TestParsableTask(fake_model)
+
+        assert task.model == fake_model
+        assert isinstance(task.history, LLMHistory)
+        assert task.default_max_retries == 5
+
+    def test_initialization_with_history(self, fake_model, history):
+        """Test ParsableLLMTask initialization with custom history."""
+        task = TestParsableTask(fake_model, history)
+
+        assert task.model == fake_model
+        assert task.history == history
+        assert task.default_max_retries == 5
+
+    def test_initialization_with_custom_retries(self, fake_model):
+        """Test ParsableLLMTask initialization with custom max retries."""
+        task = TestParsableTask(fake_model, default_max_retries=3)
+
+        assert task.default_max_retries == 3
+
+    def test_parse_and_validate_not_implemented(self, fake_model):
+        """Test that _parse_and_validate raises NotImplementedError in base class."""
+        task = ParsableLLMTask(fake_model)
+
+        with pytest.raises(NotImplementedError):
+            task._parse_and_validate("test content")
+
+    def test_ask_then_parse_success_first_try(self, model_always_valid):
+        """Test successful parsing on first attempt."""
+        task = TestParsableTask(model_always_valid)
+
+        result = task.ask_then_parse(input_content="test", prompt="test prompt")
+
+        assert result == {"valid": "json"}
+
+    def test_ask_then_parse_success_after_retries(self, model_with_responses):
+        """Test successful parsing after several failed attempts."""
+        task = TestParsableTask(model_with_responses)
+
+        result = task.ask_then_parse(input_content="test", max_retries=5)
+
+        assert result == {"valid": "json"}
+
+    def test_ask_then_parse_failure_all_retries(self, model_always_invalid):
+        """Test failure after exhausting all retry attempts."""
+        task = TestParsableTask(model_always_invalid)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=3)
+
+        exception = exc_info.value
+        assert "Output parse failed after 3 tries" in str(exception)
+        assert len(exception.tries) == 3
+
+        for attempt in exception.tries:
+            assert attempt.output == "invalid_response"
+            assert isinstance(attempt.exception, Exception)
+
+    def test_ask_then_parse_with_custom_max_retries(self, model_always_invalid):
+        """Test ask_then_parse with custom max_retries parameter."""
+        task = TestParsableTask(model_always_invalid)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=2)
+
+        exception = exc_info.value
+        assert len(exception.tries) == 2
+
+    def test_ask_then_parse_uses_default_max_retries(self, model_always_invalid):
+        """Test that ask_then_parse uses default_max_retries when max_retries is None."""
+        task = TestParsableTask(model_always_invalid, default_max_retries=4)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test")
+
+        exception = exc_info.value
+        assert len(exception.tries) == 4
+
+    def test_ask_then_parse_without_input_content(self, model_always_valid):
+        """Test ask_then_parse without input_content parameter."""
+        task = TestParsableTask(model_always_valid)
+
+        result = task.ask_then_parse(prompt="test prompt")
+
+        assert result == {"valid": "json"}
+
+    def test_ask_then_parse_with_additional_params(self, model_always_valid):
+        """Test ask_then_parse with additional parameters passed to ask method."""
+        task = TestParsableTask(model_always_valid)
+
+        result = task.ask_then_parse(
+            input_content="test",
+            prompt="test prompt",
+            temperature=0.7,
+            max_tokens=100
+        )
+
+        assert result == {"valid": "json"}
+
+    def test_custom_exceptions_handling(self):
+        """Test handling of custom exception types."""
+        model = FakeLLMModel().response_sequence([
+            "value_error",
+            "key_error",
+            "valid_response"
+        ])
+        task = TestParsableTaskWithCustomExceptions(model)
+
+        result = task.ask_then_parse(input_content="test", max_retries=5)
+
+        assert result == "valid_response"
+
+    def test_non_matching_exception_propagates(self):
+        """Test that exceptions not matching __exceptions__ propagate immediately."""
+        model = FakeLLMModel().response_always("type_error")
+        task = TestParsableTaskWithCustomExceptions(model)
+
+        with pytest.raises(TypeError) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=5)
+
+        assert "Type error" in str(exc_info.value)
+
+    def test_default_exceptions_catches_all(self):
+        """Test that default __exceptions__ = Exception catches all exceptions."""
+        model = FakeLLMModel().response_always("any_error")
+        task = TestParsableTaskAlwaysFails(model)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=2)
+
+        exception = exc_info.value
+        assert len(exception.tries) == 2
+
+    def test_output_parse_failed_message_singular(self, model_always_invalid):
+        """Test OutputParseFailed message with singular 'try'."""
+        task = TestParsableTask(model_always_invalid)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=1)
+
+        exception = exc_info.value
+        assert "Output parse failed after 1 try." in str(exception)
+
+    def test_output_parse_failed_message_plural(self, model_always_invalid):
+        """Test OutputParseFailed message with plural 'tries'."""
+        task = TestParsableTask(model_always_invalid)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=3)
+
+        exception = exc_info.value
+        assert "Output parse failed after 3 tries." in str(exception)
+
+    def test_inheritance_from_llm_task(self, fake_model):
+        """Test that ParsableLLMTask inherits from LLMTask."""
+
+        task = TestParsableTask(fake_model)
+
+        assert isinstance(task, LLMTask)
+
+    def test_sequence_responses_with_retries(self):
+        """Test sequence responses with multiple retries and eventual success."""
+        responses = [
+            "invalid1",
+            "invalid2",
+            "invalid3",
+            '{"success": true}'
+        ]
+        model = FakeLLMModel().response_sequence(responses)
+        task = TestParsableTask(model)
+
+        result = task.ask_then_parse(input_content="test", max_retries=5)
+
+        assert result == {"success": True}
+
+    def test_sequence_responses_exhausted_before_success(self):
+        """Test when sequence responses are exhausted before finding valid response."""
+        responses = ["invalid1", "invalid2"]
+        model = FakeLLMModel().response_sequence(responses)
+        task = TestParsableTask(model)
+
+        with pytest.raises(AssertionError):  # No response rule found
+            task.ask_then_parse(input_content="test", max_retries=5)
+
+    def test_zero_max_retries(self, model_always_invalid):
+        """Test behavior with zero max retries."""
+        task = TestParsableTask(model_always_invalid)
+
+        with pytest.raises(OutputParseFailed) as exc_info:
+            task.ask_then_parse(input_content="test", max_retries=0)
+
+        exception = exc_info.value
+        assert len(exception.tries) == 0
+        assert "Output parse failed after 0 tries." in str(exception)
+
+    def test_inheritance_methods_available(self, fake_model):
+        """Test that inherited methods from LLMTask are available."""
+        task = TestParsableTask(fake_model)
+
+        # Test that we can access inherited methods
+        assert hasattr(task, 'ask')
+        assert hasattr(task, 'ask_stream')
+        assert hasattr(task, '_logger')
+        assert hasattr(task, 'model')
+        assert hasattr(task, 'history')

--- a/test/testing/test_alive.py
+++ b/test/testing/test_alive.py
@@ -14,49 +14,37 @@ def mock_model():
 @pytest.fixture
 def hello_model():
     """Create a FakeLLMModel that responds to hello messages."""
-    model = FakeLLMModel()
-    model.response_when_keyword_in_last_message('hello', 'Hello! How can I help you?')
-    return model
+    return FakeLLMModel().response_when_keyword_in_last_message('hello', 'Hello! How can I help you?')
 
 
 @pytest.fixture
 def empty_response_model():
     """Create a FakeLLMModel that returns empty responses."""
-    model = FakeLLMModel()
-    model.response_always('')
-    return model
+    return FakeLLMModel().response_always('')
 
 
 @pytest.fixture
 def ping_pong_model():
     """Create a FakeLLMModel that responds to ping with pong."""
-    model = FakeLLMModel()
-    model.response_when_keyword_in_last_message('ping', 'Pong!')
-    return model
+    return FakeLLMModel().response_when_keyword_in_last_message('ping', 'Pong!')
 
 
 @pytest.fixture
 def no_pong_model():
     """Create a FakeLLMModel that doesn't respond with pong."""
-    model = FakeLLMModel()
-    model.response_always('Hello there!')
-    return model
+    return FakeLLMModel().response_always('Hello there!')
 
 
 @pytest.fixture
 def case_insensitive_pong_model():
     """Create a FakeLLMModel that responds with uppercase PONG."""
-    model = FakeLLMModel()
-    model.response_when_keyword_in_last_message('ping', 'PONG!')
-    return case_insensitive_pong_model
+    return FakeLLMModel().response_when_keyword_in_last_message('ping', 'PONG!')
 
 
 @pytest.fixture
 def pong_in_sentence_model():
     """Create a FakeLLMModel that has pong within a sentence."""
-    model = FakeLLMModel()
-    model.response_when_keyword_in_last_message('ping', 'I will respond with pong to your ping!')
-    return model
+    return FakeLLMModel().response_when_keyword_in_last_message('ping', 'I will respond with pong to your ping!')
 
 
 @pytest.mark.unittest
@@ -147,8 +135,7 @@ class TestPingFunction:
         test_cases = ['pong', 'PONG', 'Pong', 'PoNg', 'pOnG']
 
         for case in test_cases:
-            model = FakeLLMModel()
-            model.response_when_keyword_in_last_message('ping', case)
+            model = FakeLLMModel().response_when_keyword_in_last_message('ping', case)
 
             result = ping(model, n=1)
 


### PR DESCRIPTION
* [x] refactor LLMHistory
  * [x] Refactor it to immutable object
  * [x] Rename append --> with
  * [x] Add `__eq__` and `__hash__`
  * [x] Add json and yaml dump and load function
* [x] Add hash system for LLMTask, to avoid inferencing many times
  * [x] Add `__eq__` and `__hash__` to LLMModel (FakeLLMModel, RemoteLLMModel)
  * [x] Add `__eq__` and `__hash__` to LLMHTask
* [x] Add complete the data model parse system, especially pydantic ones

But, unittest for datamodel system still WIP, will complete it in the future